### PR TITLE
✨ feat(cli): pr-lens canvas push, pull and rotate

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -120,7 +120,7 @@ Puts the document on prlens.dev as a canvas: a page anyone with the link can rea
 
 The view link is the one to share. The edit link is the same page with the write token in the fragment, and anyone holding it can push over your canvas, so it stays with you. The embed is the hero diagram as an SVG, for a README or a wiki.
 
-`pull` fetches the document back, by the view link or the bare id, into `.pr-lens/graph.json` unless `-o` says otherwise. A push carries the revision it last saw, and one that has been overtaken is refused rather than applied: pull, then push again.
+`pull` fetches the document back, by the view link or the bare id, into `.pr-lens/graph.json` unless `-o` says otherwise, and records the revision. Pull the edit link, the one ending in `#w=…`, and its token is recorded too: that is how a fresh checkout, or one that lost `.pr-lens/canvas.json`, gets the canvas back. A push carries the revision it last saw, and one that has been overtaken is refused rather than applied: pull, then push again.
 
 `rotate` mints a new write token and retires the old one, which is the whole answer to an edit link that got out. The new token is written to the registry before the app hears of it, so a connection that drops mid-way is finished by the next command rather than lost. The token lives in `.pr-lens/canvas.json`, keyed by canvas id, and git ignores it. Lose that file and the canvas is still readable by everyone; pushing to it again needs the token, which the edit link still carries.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -122,7 +122,9 @@ The view link is the one to share. The edit link is the same page with the write
 
 `pull` fetches the document back, by the view link or the bare id, into `.pr-lens/graph.json` unless `-o` says otherwise. A push carries the revision it last saw, and one that has been overtaken is refused rather than applied: pull, then push again.
 
-`rotate` mints a new write token and retires the old one, which is the whole answer to an edit link that got out. The token lives in `.pr-lens/canvas.json`, keyed by canvas id, and git ignores it. Lose that file and the canvas is still readable by everyone; pushing to it again needs the token, which the edit link still carries.
+`rotate` mints a new write token and retires the old one, which is the whole answer to an edit link that got out. The new token is written to the registry before the app hears of it, so a connection that drops mid-way is finished by the next command rather than lost. The token lives in `.pr-lens/canvas.json`, keyed by canvas id, and git ignores it. Lose that file and the canvas is still readable by everyone; pushing to it again needs the token, which the edit link still carries.
+
+The registry is written only where git will never take it: a checkout that tracks `.pr-lens/canvas.json`, or un-ignores `.pr-lens/`, gets a `CANVAS_REGISTRY_EXPOSED` refusal instead of a token on disk.
 
 `--api` points at another PR Lens app, or set `PR_LENS_API_URL`.
 
@@ -146,7 +148,7 @@ A lane pin may name a lane the document never declared; the band is created and 
 
 ## Failures
 
-Every failure carries a code, so a script can branch on it: `USAGE`, `UNREADABLE_FILE`, `UNKNOWN_DOCUMENT`, `INVALID_DOCUMENT`, `GIT_FAILED`, `EMPTY_DIFF`, `REPOSITORY_UNKNOWN`, `MISSING_API_KEY`, `PROVIDER_FAILED`, `MODEL_OUTPUT_INVALID`, `RENDER_FAILED`, and for `canvas`: `CANVAS_UNREGISTERED`, `CANVAS_UNKNOWN`, `CANVAS_CONFLICT`, `CANVAS_REJECTED`, `CANVAS_RATE_LIMITED`, `CANVAS_UNAVAILABLE`. Misuse exits 2, everything else exits 1.
+Every failure carries a code, so a script can branch on it: `USAGE`, `UNREADABLE_FILE`, `UNKNOWN_DOCUMENT`, `INVALID_DOCUMENT`, `GIT_FAILED`, `EMPTY_DIFF`, `REPOSITORY_UNKNOWN`, `MISSING_API_KEY`, `PROVIDER_FAILED`, `MODEL_OUTPUT_INVALID`, `RENDER_FAILED`, and for `canvas`: `CANVAS_UNREGISTERED`, `CANVAS_UNKNOWN`, `CANVAS_CONFLICT`, `CANVAS_REJECTED`, `CANVAS_RATE_LIMITED`, `CANVAS_UNAVAILABLE`, `CANVAS_REGISTRY_EXPOSED`. Misuse exits 2, everything else exits 1.
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -19,10 +19,10 @@ pr-lens analyze --base origin/main --head HEAD
 
 Three request shapes are implemented rather than a list of vendors:
 
-| `--provider` | Endpoint | Key |
-| --- | --- | --- |
-| `gemini` (default) | Google's own API | `GEMINI_API_KEY` |
-| `openai` | OpenAI's own API | `OPENAI_API_KEY` |
+| `--provider`        | Endpoint                                                          | Key              |
+| ------------------- | ----------------------------------------------------------------- | ---------------- |
+| `gemini` (default)  | Google's own API                                                  | `GEMINI_API_KEY` |
+| `openai`            | OpenAI's own API                                                  | `OPENAI_API_KEY` |
 | `openai-compatible` | anything else speaking `/chat/completions`, named by `--base-url` | `OPENAI_API_KEY` |
 
 DeepSeek, Anthropic's compatibility endpoint, OpenRouter, Ollama and llama.cpp are all reached by pointing `--base-url` at them, and a new vendor needs no release here. OpenAI is listed separately from the servers that copied it because the two have drifted: it renamed the output limit to `max_completion_tokens` and its newer models reject `max_tokens`, which is the only spelling the others know. There is no field both accept, so you say which endpoint you are talking to rather than the CLI guessing from a hostname.
@@ -43,7 +43,7 @@ None of it is meant to be committed. The SVGs, the document and the manifest are
 
 `--out` overrides the location on every command that writes. Point it somewhere else and PR Lens leaves your `.gitignore` alone: that directory is yours to decide about.
 
-`canvas` keeps one more file there, `.pr-lens/canvas.json`, which holds the write token for every canvas this checkout has pushed. It is the one file in the directory that cannot be rebuilt, and the reason the directory is ignored matters twice over.
+`canvas` keeps one more file there, `.pr-lens/canvas.json`, which holds the write token for every canvas this checkout has pushed. It is the one file in the directory that cannot be rebuilt, and a bigger reason the directory is ignored.
 
 ## The commands
 
@@ -71,7 +71,7 @@ pr-lens render .pr-lens/graph.json
 
 Draws the document as self-contained light and dark SVGs (one pair per drill-down section per lens, or one pair per lens when the document has no sections), and writes two files beside them: `manifest.json`, which says what was drawn and under which file name, and `drawn.graph.json`, the document those pictures actually show.
 
-Both matter to what comes next. The manifest is where `comment` gets its file names, so neither command re-derives the other's. And `drawn.graph.json` exists because this is where corrections are applied: excluding a node can empty out a whole drill-down section, and the renderer then draws no picture for it. A comment composed from the document that went *in* would announce a section that came out of nothing.
+Both matter to what comes next. The manifest is where `comment` gets its file names, so neither command re-derives the other's. And `drawn.graph.json` exists because this is where corrections are applied: excluding a node can empty out a whole drill-down section, and the renderer then draws no picture for it. A comment composed from the document that went _in_ would announce a section that came out of nothing.
 
 The SVGs carry no script and no external reference, and the same document renders to the same bytes every time. `--theme light` or `--theme dark` draws one half of the pair.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -108,7 +108,7 @@ The map is a snapshot, not a source of truth. Nothing reads it back into the pip
 pr-lens canvas push
 ```
 
-Puts the document on prlens.dev as a canvas: a page anyone with the link can read, and an SVG a README can embed. Three verbs.
+Puts the document on prlens.dev as a canvas: a page anyone with the link can read, and an SVG a README can embed.
 
 `push` sends the JSON document, never an SVG; the app draws it. The default is `.pr-lens/drawn.graph.json`, the document `render` drew, so what the page shows is what the diagrams show. The first push of a file mints a canvas and every push after that updates the same one, matched by the path it came from. `--canvas <id|name>` picks a different one and `--name` says what to call a new one; the document's title is the default. It prints three links:
 
@@ -122,11 +122,11 @@ The view link is the one to share. The edit link is the same page with the write
 
 `pull` fetches the document back, by the view link or the bare id, into `.pr-lens/graph.json` unless `-o` says otherwise, and records the revision. Pull the edit link, the one ending in `#w=…`, and its token is recorded too: that is how a fresh checkout, or one that lost `.pr-lens/canvas.json`, gets the canvas back. A push carries the revision it last saw, and one that has been overtaken is refused rather than applied: pull, then push again.
 
-`rotate` mints a new write token and retires the old one, which is the whole answer to an edit link that got out. The new token is written to the registry before the app hears of it, so a connection that drops mid-way is finished by the next command rather than lost. The token lives in `.pr-lens/canvas.json`, keyed by canvas id, and git ignores it. Lose that file and the canvas is still readable by everyone; pushing to it again needs the token, which the edit link still carries.
+`rotate` mints a new write token and retires the old one. Use it when an edit link has leaked. The CLI saves the new token before it sends the request, so if the connection drops, the next command finishes the rotation instead of losing the token. The token lives in `.pr-lens/canvas.json`, keyed by canvas id, and git ignores it. Lose that file and the canvas is still readable by everyone; pushing to it again needs the token, which the edit link still carries.
 
-Registry writes take a lock, `.pr-lens/canvas.json.lock`, and never take one away from another command; a lock left by a command that died is reported with its process id and removed by hand.
+Registry writes take a lock at `.pr-lens/canvas.json.lock`. The CLI never removes another command's lock. If a command dies and leaves one behind, the error names its process id and you remove the file yourself.
 
-The registry is written only where git will never take it: a checkout that tracks `.pr-lens/canvas.json`, or un-ignores `.pr-lens/`, gets a `CANVAS_REGISTRY_EXPOSED` refusal instead of a token on disk.
+The CLI refuses to write the registry where git could commit it. If a checkout tracks `.pr-lens/canvas.json` or un-ignores `.pr-lens/`, the command fails with `CANVAS_REGISTRY_EXPOSED` and writes nothing.
 
 `--api` points at another PR Lens app, or set `PR_LENS_API_URL`.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -10,7 +10,7 @@ npx @coldtea/pr-lens-cli analyze --base origin/main
 
 ## Bring your own key
 
-Only `analyze` talks to a model; `render`, `comment`, `validate` and `export` never do. Its key is read from the environment, never from a flag: a flag lands in shell history and in the log of whatever CI runs it. The diff goes to the provider you name and nowhere else: there is no PR Lens service in this path.
+Only `analyze` talks to a model; `render`, `comment`, `validate`, `export` and `canvas` never do. Its key is read from the environment, never from a flag: a flag lands in shell history and in the log of whatever CI runs it. The diff goes to the provider you name and nowhere else: there is no PR Lens service in this path.
 
 ```bash
 export GEMINI_API_KEY=…      # Gemini is the default, not a requirement
@@ -42,6 +42,8 @@ pr-lens analyze --base origin/main \
 None of it is meant to be committed. The SVGs, the document and the manifest are rebuilt from the diff whenever anyone wants them, and a diagram of a pull request that merged months ago is worse than no diagram. What is meant to last is the comment on the pull request, and the map `export` writes.
 
 `--out` overrides the location on every command that writes. Point it somewhere else and PR Lens leaves your `.gitignore` alone: that directory is yours to decide about.
+
+`canvas` keeps one more file there, `.pr-lens/canvas.json`, which holds the write token for every canvas this checkout has pushed. It is the one file in the directory that cannot be rebuilt, and the reason the directory is ignored matters twice over.
 
 ## The commands
 
@@ -100,6 +102,30 @@ Turns a pull-request document into the map of the system once that pull request 
 
 The map is a snapshot, not a source of truth. Nothing reads it back into the pipeline: a committed map that overrode inference would be hand-maintained rot with merge conflicts attached. Commit it so a repository has something to read, to diff, and to hand an agent.
 
+### `canvas`
+
+```bash
+pr-lens canvas push
+```
+
+Puts the document on prlens.dev as a canvas: a page anyone with the link can read, and an SVG a README can embed. Three verbs.
+
+`push` sends the JSON document, never an SVG; the app draws it. The default is `.pr-lens/drawn.graph.json`, the document `render` drew, so what the page shows is what the diagrams show. The first push of a file mints a canvas and every push after that updates the same one, matched by the path it came from. `--canvas <id|name>` picks a different one and `--name` says what to call a new one; the document's title is the default. It prints three links:
+
+```
+✓ https://prlens.dev/c/{id} — rev 1 · 4 diagrams
+  edit link, keep it to yourself: https://prlens.dev/c/{id}#w=…
+  README embed: https://prlens.dev/c/{id}.svg
+```
+
+The view link is the one to share. The edit link is the same page with the write token in the fragment, and anyone holding it can push over your canvas, so it stays with you. The embed is the hero diagram as an SVG, for a README or a wiki.
+
+`pull` fetches the document back, by the view link or the bare id, into `.pr-lens/graph.json` unless `-o` says otherwise. A push carries the revision it last saw, and one that has been overtaken is refused rather than applied: pull, then push again.
+
+`rotate` mints a new write token and retires the old one, which is the whole answer to an edit link that got out. The token lives in `.pr-lens/canvas.json`, keyed by canvas id, and git ignores it. Lose that file and the canvas is still readable by everyone; pushing to it again needs the token, which the edit link still carries.
+
+`--api` points at another PR Lens app, or set `PR_LENS_API_URL`.
+
 ## Corrections
 
 A repository's `.github/pr-lens.yml` is picked up automatically by `render` and applied at draw time: renames, exclusions, lane pins, groupings. It is an overlay: inference never writes back into it, so a correction keeps holding as the code moves and the model renames things between runs, and the document on disk stays the record of what was inferred.
@@ -120,7 +146,7 @@ A lane pin may name a lane the document never declared; the band is created and 
 
 ## Failures
 
-Every failure carries a code, so a script can branch on it: `USAGE`, `UNREADABLE_FILE`, `UNKNOWN_DOCUMENT`, `INVALID_DOCUMENT`, `GIT_FAILED`, `EMPTY_DIFF`, `REPOSITORY_UNKNOWN`, `MISSING_API_KEY`, `PROVIDER_FAILED`, `MODEL_OUTPUT_INVALID`, `RENDER_FAILED`. Misuse exits 2, everything else exits 1.
+Every failure carries a code, so a script can branch on it: `USAGE`, `UNREADABLE_FILE`, `UNKNOWN_DOCUMENT`, `INVALID_DOCUMENT`, `GIT_FAILED`, `EMPTY_DIFF`, `REPOSITORY_UNKNOWN`, `MISSING_API_KEY`, `PROVIDER_FAILED`, `MODEL_OUTPUT_INVALID`, `RENDER_FAILED`, and for `canvas`: `CANVAS_UNREGISTERED`, `CANVAS_UNKNOWN`, `CANVAS_CONFLICT`, `CANVAS_REJECTED`, `CANVAS_RATE_LIMITED`, `CANVAS_UNAVAILABLE`. Misuse exits 2, everything else exits 1.
 
 ---
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -124,6 +124,8 @@ The view link is the one to share. The edit link is the same page with the write
 
 `rotate` mints a new write token and retires the old one, which is the whole answer to an edit link that got out. The new token is written to the registry before the app hears of it, so a connection that drops mid-way is finished by the next command rather than lost. The token lives in `.pr-lens/canvas.json`, keyed by canvas id, and git ignores it. Lose that file and the canvas is still readable by everyone; pushing to it again needs the token, which the edit link still carries.
 
+Registry writes take a lock, `.pr-lens/canvas.json.lock`, and never take one away from another command; a lock left by a command that died is reported with its process id and removed by hand.
+
 The registry is written only where git will never take it: a checkout that tracks `.pr-lens/canvas.json`, or un-ignores `.pr-lens/`, gets a `CANVAS_REGISTRY_EXPOSED` refusal instead of a token on disk.
 
 `--api` points at another PR Lens app, or set `PR_LENS_API_URL`.

--- a/packages/cli/src/canvas/api.ts
+++ b/packages/cli/src/canvas/api.ts
@@ -159,8 +159,11 @@ const call = async <T>(api: string, request: Request, schema: z.ZodType<T>): Pro
     headers,
     body: request.body === undefined ? undefined : JSON.stringify(request.body),
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  }).catch((error: unknown) => {
-    throw unavailable(api, undefined, error instanceof Error ? error.message : undefined);
+  }).catch(() => {
+    // The runtime's own words for a failed connection name addresses and
+    // internals; the reader needs to know the app was not reached, and how
+    // to check.
+    throw unavailable(api, undefined, "check the address and the connection, then try again");
   });
 
   const body = parseJson(await response.text());

--- a/packages/cli/src/canvas/api.ts
+++ b/packages/cli/src/canvas/api.ts
@@ -65,6 +65,7 @@ const Refusal = z.discriminatedUnion("code", [
     message: z.string(),
     issues: z.array(z.object({ code: z.string(), path: z.string(), message: z.string() })),
   }),
+  z.object({ code: z.literal("CANNOT_DRAW"), message: z.string() }),
   z.object({ code: z.literal("REVISION_MOVED"), message: z.string(), rev: z.number().int() }),
   z.object({ code: z.literal("RATE_LIMITED"), message: z.string(), retryAt: z.string() }),
   z.object({ code: z.literal("TOO_LARGE"), message: z.string() }),
@@ -126,6 +127,10 @@ const refusal = (api: string, request: Request, status: number, body: unknown): 
         error.message,
         error.issues.map((issue) => (issue.path === "" ? issue.message : `${issue.path}: ${issue.message}`)).join("\n"),
       );
+    case "CANNOT_DRAW":
+      // The document passed the contract and the renderer still had nothing to
+      // draw; the app's own words say why, and there is no issue list to add.
+      return new PrLensCliError("CANVAS_REJECTED", error.message);
     case "RATE_LIMITED":
       return new PrLensCliError(
         "CANVAS_RATE_LIMITED",

--- a/packages/cli/src/canvas/api.ts
+++ b/packages/cli/src/canvas/api.ts
@@ -166,7 +166,11 @@ const call = async <T>(api: string, request: Request, schema: z.ZodType<T>): Pro
     throw unavailable(api, undefined, "check the address and the connection, then try again");
   });
 
-  const body = parseJson(await response.text());
+  // The connection can fail after the headers as well as before them.
+  const text = await response.text().catch(() => {
+    throw unavailable(api, response.status, "the answer was cut off; check the connection, then try again");
+  });
+  const body = parseJson(text);
   if (!response.ok) throw refusal(api, request, response.status, body);
 
   const parsed = schema.safeParse(body);

--- a/packages/cli/src/canvas/api.ts
+++ b/packages/cli/src/canvas/api.ts
@@ -44,7 +44,7 @@ const Pushed = z.object({
   tiles: z.array(Tile),
 });
 
-const Rotated = z.object({ id: z.string(), writeToken: z.string(), editUrl: z.string() });
+const Rotated = z.object({ id: z.string(), editUrl: z.string() });
 
 export type Minted = z.infer<typeof Minted>;
 export type Pushed = z.infer<typeof Pushed>;
@@ -200,5 +200,14 @@ export const pushCanvas = (
 ): Promise<Pushed> =>
   call(api, { method: "PUT", path: canvasPath(id), canvas: id, token, ifMatch: rev, body: document }, Pushed);
 
-export const rotateCanvas = (api: string, id: string, token: string): Promise<Rotated> =>
-  call(api, { method: "POST", path: `${canvasPath(id)}/rotate`, canvas: id, token }, Rotated);
+/**
+ * The next token is minted here and sent along, so the app's answer can be
+ * lost and the same question asked again: once the token is on record, the
+ * app says so whichever bearer is presented.
+ */
+export const rotateCanvas = (api: string, id: string, token: string, nextToken: string): Promise<Rotated> =>
+  call(
+    api,
+    { method: "POST", path: `${canvasPath(id)}/rotate`, canvas: id, token, body: { writeToken: nextToken } },
+    Rotated,
+  );

--- a/packages/cli/src/canvas/api.ts
+++ b/packages/cli/src/canvas/api.ts
@@ -1,4 +1,8 @@
-import { assertNever, safeParseGraphDoc, type GraphDoc } from "@coldtea/pr-lens-schema";
+import {
+  assertNever,
+  safeParseGraphDoc,
+  type GraphDoc,
+} from "@coldtea/pr-lens-schema";
 import { z } from "zod";
 import { PrLensCliError } from "../errors.js";
 import { CLI_VERSION } from "../version.js";
@@ -49,10 +53,14 @@ const Rotated = z.object({ id: z.string(), editUrl: z.string() });
 export type Minted = z.infer<typeof Minted>;
 export type Pushed = z.infer<typeof Pushed>;
 export type Rotated = z.infer<typeof Rotated>;
-export type Fetched = Omit<z.infer<typeof Fetched>, "document"> & { document: GraphDoc };
+export type Fetched = Omit<z.infer<typeof Fetched>, "document"> & {
+  document: GraphDoc;
+};
 
 /** Loose inner object: an unknown code must still reach the refusal below. */
-const Envelope = z.object({ error: z.looseObject({ code: z.string(), message: z.string() }) });
+const Envelope = z.object({
+  error: z.looseObject({ code: z.string(), message: z.string() }),
+});
 
 const Refusal = z.discriminatedUnion("code", [
   z.object({ code: z.literal("NOT_FOUND"), message: z.string() }),
@@ -60,11 +68,21 @@ const Refusal = z.discriminatedUnion("code", [
   z.object({
     code: z.literal("INVALID_DOCUMENT"),
     message: z.string(),
-    issues: z.array(z.object({ code: z.string(), path: z.string(), message: z.string() })),
+    issues: z.array(
+      z.object({ code: z.string(), path: z.string(), message: z.string() }),
+    ),
   }),
   z.object({ code: z.literal("CANNOT_DRAW"), message: z.string() }),
-  z.object({ code: z.literal("REVISION_MOVED"), message: z.string(), rev: z.number().int() }),
-  z.object({ code: z.literal("RATE_LIMITED"), message: z.string(), retryAt: z.string() }),
+  z.object({
+    code: z.literal("REVISION_MOVED"),
+    message: z.string(),
+    rev: z.number().int(),
+  }),
+  z.object({
+    code: z.literal("RATE_LIMITED"),
+    message: z.string(),
+    retryAt: z.string(),
+  }),
   z.object({ code: z.literal("TOO_LARGE"), message: z.string() }),
 ]);
 
@@ -80,10 +98,16 @@ type Request = {
 
 const hostOf = (api: string): string => new URL(api).host;
 
-const unavailable = (api: string, status: number | undefined, details?: string): PrLensCliError =>
+const unavailable = (
+  api: string,
+  status: number | undefined,
+  details?: string,
+): PrLensCliError =>
   new PrLensCliError(
     "CANVAS_UNAVAILABLE",
-    status === undefined ? `${hostOf(api)} did not answer` : `${hostOf(api)} answered ${status}`,
+    status === undefined
+      ? `${hostOf(api)} did not answer`
+      : `${hostOf(api)} answered ${status}`,
     details,
   );
 
@@ -95,12 +119,18 @@ const parseJson = (text: string): unknown => {
   }
 };
 
-const refusal = (api: string, request: Request, status: number, body: unknown): PrLensCliError => {
+const refusal = (
+  api: string,
+  request: Request,
+  status: number,
+  body: unknown,
+): PrLensCliError => {
   const envelope = Envelope.safeParse(body);
   if (!envelope.success) return unavailable(api, status);
 
   const known = Refusal.safeParse(envelope.data.error);
-  if (!known.success) return unavailable(api, status, envelope.data.error.message);
+  if (!known.success)
+    return unavailable(api, status, envelope.data.error.message);
 
   const error = known.data;
   switch (error.code) {
@@ -122,7 +152,13 @@ const refusal = (api: string, request: Request, status: number, body: unknown): 
       return new PrLensCliError(
         "CANVAS_REJECTED",
         error.message,
-        error.issues.map((issue) => (issue.path === "" ? issue.message : `${issue.path}: ${issue.message}`)).join("\n"),
+        error.issues
+          .map((issue) =>
+            issue.path === ""
+              ? issue.message
+              : `${issue.path}: ${issue.message}`,
+          )
+          .join("\n"),
       );
     case "CANNOT_DRAW":
       // Passed the contract but nothing to draw; the app's message says why.
@@ -141,13 +177,22 @@ const refusal = (api: string, request: Request, status: number, body: unknown): 
   }
 };
 
-const call = async <T>(api: string, request: Request, schema: z.ZodType<T>): Promise<T> => {
+const call = async <T>(
+  api: string,
+  request: Request,
+  schema: z.ZodType<T>,
+): Promise<T> => {
   const headers: Record<string, string> = {
     accept: "application/json",
     "user-agent": `pr-lens-cli/${CLI_VERSION}`,
   };
-  if (request.token !== undefined) headers.authorization = `Bearer ${request.token}`;
-  if (request.ifMatch !== undefined) headers["if-match"] = String(request.ifMatch);
+
+  if (request.token !== undefined)
+    headers.authorization = `Bearer ${request.token}`;
+
+  if (request.ifMatch !== undefined)
+    headers["if-match"] = String(request.ifMatch);
+
   if (request.body !== undefined) headers["content-type"] = "application/json";
 
   const response = await fetch(`${api}${request.path}`, {
@@ -157,19 +202,32 @@ const call = async <T>(api: string, request: Request, schema: z.ZodType<T>): Pro
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   }).catch(() => {
     // The runtime's message names addresses and internals; keep it out.
-    throw unavailable(api, undefined, "check the address and the connection, then try again");
+    throw unavailable(
+      api,
+      undefined,
+      "check the address and the connection, then try again",
+    );
   });
 
   // A body can fail after the headers arrived.
   const text = await response.text().catch(() => {
-    throw unavailable(api, response.status, "the answer was cut off; check the connection, then try again");
+    throw unavailable(
+      api,
+      response.status,
+      "the answer was cut off; check the connection, then try again",
+    );
   });
   const body = parseJson(text);
   if (!response.ok) throw refusal(api, request, response.status, body);
 
   const parsed = schema.safeParse(body);
   if (!parsed.success)
-    throw unavailable(api, response.status, "the answer was not in the shape the canvas API documents");
+    throw unavailable(
+      api,
+      response.status,
+      "the answer was not in the shape the canvas API documents",
+    );
+
   return parsed.data;
 };
 
@@ -178,8 +236,15 @@ const canvasPath = (id: string): string => `/api/canvas/${id}`;
 export const mintCanvas = (api: string): Promise<Minted> =>
   call(api, { method: "POST", path: "/api/canvas", canvas: undefined }, Minted);
 
-export const fetchCanvas = async (api: string, id: string): Promise<Fetched> => {
-  const fetched = await call(api, { method: "GET", path: canvasPath(id), canvas: id }, Fetched);
+export const fetchCanvas = async (
+  api: string,
+  id: string,
+): Promise<Fetched> => {
+  const fetched = await call(
+    api,
+    { method: "GET", path: canvasPath(id), canvas: id },
+    Fetched,
+  );
 
   const document = safeParseGraphDoc(fetched.document);
   if (!document.ok)
@@ -199,22 +264,49 @@ export const pushCanvas = (
   rev: number,
   document: GraphDoc,
 ): Promise<Pushed> =>
-  call(api, { method: "PUT", path: canvasPath(id), canvas: id, token, ifMatch: rev, body: document }, Pushed);
+  call(
+    api,
+    {
+      method: "PUT",
+      path: canvasPath(id),
+      canvas: id,
+      token,
+      ifMatch: rev,
+      body: document,
+    },
+    Pushed,
+  );
 
 /** A rotation onto itself changes nothing and is answered "rotated" only for the current token. */
-export const verifyWriteToken = (api: string, id: string, token: string): Promise<boolean> =>
+export const verifyWriteToken = (
+  api: string,
+  id: string,
+  token: string,
+): Promise<boolean> =>
   rotateCanvas(api, id, token, token).then(
     () => true,
     (error: unknown) => {
-      if (error instanceof PrLensCliError && error.code === "CANVAS_UNKNOWN") return false;
+      if (error instanceof PrLensCliError && error.code === "CANVAS_UNKNOWN")
+        return false;
       throw error;
     },
   );
 
 /** The caller mints the next token, so a lost answer can be asked for again. */
-export const rotateCanvas = (api: string, id: string, token: string, nextToken: string): Promise<Rotated> =>
+export const rotateCanvas = (
+  api: string,
+  id: string,
+  token: string,
+  nextToken: string,
+): Promise<Rotated> =>
   call(
     api,
-    { method: "POST", path: `${canvasPath(id)}/rotate`, canvas: id, token, body: { writeToken: nextToken } },
+    {
+      method: "POST",
+      path: `${canvasPath(id)}/rotate`,
+      canvas: id,
+      token,
+      body: { writeToken: nextToken },
+    },
     Rotated,
   );

--- a/packages/cli/src/canvas/api.ts
+++ b/packages/cli/src/canvas/api.ts
@@ -1,0 +1,199 @@
+import { assertNever, safeParseGraphDoc, type GraphDoc } from "@coldtea/pr-lens-schema";
+import { z } from "zod";
+import { PrLensCliError } from "../errors.js";
+import { CLI_VERSION } from "../version.js";
+
+const REQUEST_TIMEOUT_MS = 60_000;
+
+const Tile = z.object({
+  id: z.string(),
+  title: z.string(),
+  lens: z.string(),
+  crumbs: z.array(z.string()),
+  hero: z.boolean(),
+  width: z.number(),
+  height: z.number(),
+  renders: z.record(z.string(), z.string()),
+  images: z.record(z.string(), z.string()),
+});
+
+const Minted = z.object({
+  id: z.string(),
+  writeToken: z.string(),
+  rev: z.number().int(),
+  viewUrl: z.string(),
+  editUrl: z.string(),
+  embedUrl: z.string(),
+});
+
+const Fetched = z.object({
+  id: z.string(),
+  rev: z.number().int(),
+  viewUrl: z.string(),
+  embedUrl: z.string(),
+  document: z.unknown(),
+  tiles: z.array(Tile),
+});
+
+const Pushed = z.object({
+  id: z.string(),
+  rev: z.number().int(),
+  viewUrl: z.string(),
+  editUrl: z.string(),
+  embedUrl: z.string(),
+  tiles: z.array(Tile),
+});
+
+const Rotated = z.object({ id: z.string(), writeToken: z.string(), editUrl: z.string() });
+
+export type Minted = z.infer<typeof Minted>;
+export type Pushed = z.infer<typeof Pushed>;
+export type Rotated = z.infer<typeof Rotated>;
+export type Fetched = Omit<z.infer<typeof Fetched>, "document"> & { document: GraphDoc };
+
+/**
+ * Every error the app sends wears this envelope; the known codes carry more,
+ * and the inner object is left loose so the refusal below still sees it.
+ */
+const Envelope = z.object({ error: z.looseObject({ code: z.string(), message: z.string() }) });
+
+const Refusal = z.discriminatedUnion("code", [
+  z.object({ code: z.literal("NOT_FOUND"), message: z.string() }),
+  z.object({ code: z.literal("INVALID_REQUEST"), message: z.string() }),
+  z.object({
+    code: z.literal("INVALID_DOCUMENT"),
+    message: z.string(),
+    issues: z.array(z.object({ code: z.string(), path: z.string(), message: z.string() })),
+  }),
+  z.object({ code: z.literal("REVISION_MOVED"), message: z.string(), rev: z.number().int() }),
+  z.object({ code: z.literal("RATE_LIMITED"), message: z.string(), retryAt: z.string() }),
+  z.object({ code: z.literal("TOO_LARGE"), message: z.string() }),
+]);
+
+type Request = {
+  method: "GET" | "POST" | "PUT";
+  path: string;
+  /** The canvas the route is about, so a 404 can name it. Minting has none. */
+  canvas: string | undefined;
+  token?: string;
+  ifMatch?: number;
+  body?: unknown;
+};
+
+const hostOf = (api: string): string => new URL(api).host;
+
+const unavailable = (api: string, status: number | undefined, details?: string): PrLensCliError =>
+  new PrLensCliError(
+    "CANVAS_UNAVAILABLE",
+    status === undefined ? `${hostOf(api)} did not answer` : `${hostOf(api)} answered ${status}`,
+    details,
+  );
+
+const parseJson = (text: string): unknown => {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+};
+
+const refusal = (api: string, request: Request, status: number, body: unknown): PrLensCliError => {
+  const envelope = Envelope.safeParse(body);
+  if (!envelope.success) return unavailable(api, status);
+
+  const known = Refusal.safeParse(envelope.data.error);
+  if (!known.success) return unavailable(api, status, envelope.data.error.message);
+
+  const error = known.data;
+  switch (error.code) {
+    case "NOT_FOUND":
+      return request.canvas === undefined
+        ? unavailable(api, status, error.message)
+        : new PrLensCliError(
+            "CANVAS_UNKNOWN",
+            `no canvas ${request.canvas} at ${hostOf(api)}, or the token is wrong`,
+            "a rotated token has to be pulled into .pr-lens/canvas.json by hand",
+          );
+    case "REVISION_MOVED":
+      return new PrLensCliError(
+        "CANVAS_CONFLICT",
+        `${request.canvas ?? "the canvas"} is at rev ${error.rev} on ${hostOf(api)}, not rev ${request.ifMatch ?? "?"}`,
+        "pr-lens canvas pull, then push again",
+      );
+    case "INVALID_DOCUMENT":
+      return new PrLensCliError(
+        "CANVAS_REJECTED",
+        error.message,
+        error.issues.map((issue) => (issue.path === "" ? issue.message : `${issue.path}: ${issue.message}`)).join("\n"),
+      );
+    case "RATE_LIMITED":
+      return new PrLensCliError(
+        "CANVAS_RATE_LIMITED",
+        `${hostOf(api)} is rate limiting this client until ${error.retryAt}`,
+        error.message,
+      );
+    case "INVALID_REQUEST":
+    case "TOO_LARGE":
+      return unavailable(api, status, error.message);
+    default:
+      return assertNever(error, "Unhandled canvas refusal");
+  }
+};
+
+const call = async <T>(api: string, request: Request, schema: z.ZodType<T>): Promise<T> => {
+  const headers: Record<string, string> = {
+    accept: "application/json",
+    "user-agent": `pr-lens-cli/${CLI_VERSION}`,
+  };
+  if (request.token !== undefined) headers.authorization = `Bearer ${request.token}`;
+  if (request.ifMatch !== undefined) headers["if-match"] = String(request.ifMatch);
+  if (request.body !== undefined) headers["content-type"] = "application/json";
+
+  const response = await fetch(`${api}${request.path}`, {
+    method: request.method,
+    headers,
+    body: request.body === undefined ? undefined : JSON.stringify(request.body),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  }).catch((error: unknown) => {
+    throw unavailable(api, undefined, error instanceof Error ? error.message : undefined);
+  });
+
+  const body = parseJson(await response.text());
+  if (!response.ok) throw refusal(api, request, response.status, body);
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success)
+    throw unavailable(api, response.status, "the answer did not have the shape the canvas API documents");
+  return parsed.data;
+};
+
+const canvasPath = (id: string): string => `/api/canvas/${id}`;
+
+export const mintCanvas = (api: string): Promise<Minted> =>
+  call(api, { method: "POST", path: "/api/canvas", canvas: undefined }, Minted);
+
+export const fetchCanvas = async (api: string, id: string): Promise<Fetched> => {
+  const fetched = await call(api, { method: "GET", path: canvasPath(id), canvas: id }, Fetched);
+
+  const document = safeParseGraphDoc(fetched.document);
+  if (!document.ok)
+    throw new PrLensCliError(
+      "CANVAS_UNAVAILABLE",
+      `${hostOf(api)} serves a document for ${id} that this CLI cannot read [${document.error.code}]`,
+      "a newer CLI may know the shape: npx @coldtea/pr-lens-cli@latest",
+    );
+
+  return { ...fetched, document: document.value };
+};
+
+export const pushCanvas = (
+  api: string,
+  id: string,
+  token: string,
+  rev: number,
+  document: GraphDoc,
+): Promise<Pushed> =>
+  call(api, { method: "PUT", path: canvasPath(id), canvas: id, token, ifMatch: rev, body: document }, Pushed);
+
+export const rotateCanvas = (api: string, id: string, token: string): Promise<Rotated> =>
+  call(api, { method: "POST", path: `${canvasPath(id)}/rotate`, canvas: id, token }, Rotated);

--- a/packages/cli/src/canvas/api.ts
+++ b/packages/cli/src/canvas/api.ts
@@ -205,6 +205,20 @@ export const pushCanvas = (
  * lost and the same question asked again: once the token is on record, the
  * app says so whichever bearer is presented.
  */
+/**
+ * Whether a token is the one on record, without changing anything: a token
+ * turned over onto itself is answered "rotated" only when it is current, and
+ * with the reader's 404 otherwise.
+ */
+export const verifyWriteToken = (api: string, id: string, token: string): Promise<boolean> =>
+  rotateCanvas(api, id, token, token).then(
+    () => true,
+    (error: unknown) => {
+      if (error instanceof PrLensCliError && error.code === "CANVAS_UNKNOWN") return false;
+      throw error;
+    },
+  );
+
 export const rotateCanvas = (api: string, id: string, token: string, nextToken: string): Promise<Rotated> =>
   call(
     api,

--- a/packages/cli/src/canvas/api.ts
+++ b/packages/cli/src/canvas/api.ts
@@ -110,7 +110,7 @@ const refusal = (api: string, request: Request, status: number, body: unknown): 
         : new PrLensCliError(
             "CANVAS_UNKNOWN",
             `no canvas ${request.canvas} at ${hostOf(api)}, or the token is wrong`,
-            "a rotated token has to be pulled into .pr-lens/canvas.json by hand",
+            "if the token was rotated elsewhere, pull the current edit link to record it",
           );
     case "REVISION_MOVED":
       return new PrLensCliError(
@@ -125,7 +125,7 @@ const refusal = (api: string, request: Request, status: number, body: unknown): 
         error.issues.map((issue) => (issue.path === "" ? issue.message : `${issue.path}: ${issue.message}`)).join("\n"),
       );
     case "CANNOT_DRAW":
-      // Passed the contract, nothing to draw: the app's message is the whole story.
+      // Passed the contract but nothing to draw; the app's message says why.
       return new PrLensCliError("CANVAS_REJECTED", error.message);
     case "RATE_LIMITED":
       return new PrLensCliError(
@@ -169,7 +169,7 @@ const call = async <T>(api: string, request: Request, schema: z.ZodType<T>): Pro
 
   const parsed = schema.safeParse(body);
   if (!parsed.success)
-    throw unavailable(api, response.status, "the answer did not have the shape the canvas API documents");
+    throw unavailable(api, response.status, "the answer was not in the shape the canvas API documents");
   return parsed.data;
 };
 

--- a/packages/cli/src/canvas/api.ts
+++ b/packages/cli/src/canvas/api.ts
@@ -51,10 +51,7 @@ export type Pushed = z.infer<typeof Pushed>;
 export type Rotated = z.infer<typeof Rotated>;
 export type Fetched = Omit<z.infer<typeof Fetched>, "document"> & { document: GraphDoc };
 
-/**
- * Every error the app sends wears this envelope; the known codes carry more,
- * and the inner object is left loose so the refusal below still sees it.
- */
+/** Loose inner object: an unknown code must still reach the refusal below. */
 const Envelope = z.object({ error: z.looseObject({ code: z.string(), message: z.string() }) });
 
 const Refusal = z.discriminatedUnion("code", [
@@ -74,7 +71,7 @@ const Refusal = z.discriminatedUnion("code", [
 type Request = {
   method: "GET" | "POST" | "PUT";
   path: string;
-  /** The canvas the route is about, so a 404 can name it. Minting has none. */
+  /** Undefined when minting, so a 404 there is not blamed on a canvas. */
   canvas: string | undefined;
   token?: string;
   ifMatch?: number;
@@ -128,8 +125,7 @@ const refusal = (api: string, request: Request, status: number, body: unknown): 
         error.issues.map((issue) => (issue.path === "" ? issue.message : `${issue.path}: ${issue.message}`)).join("\n"),
       );
     case "CANNOT_DRAW":
-      // The document passed the contract and the renderer still had nothing to
-      // draw; the app's own words say why, and there is no issue list to add.
+      // Passed the contract, nothing to draw: the app's message is the whole story.
       return new PrLensCliError("CANVAS_REJECTED", error.message);
     case "RATE_LIMITED":
       return new PrLensCliError(
@@ -160,13 +156,11 @@ const call = async <T>(api: string, request: Request, schema: z.ZodType<T>): Pro
     body: request.body === undefined ? undefined : JSON.stringify(request.body),
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   }).catch(() => {
-    // The runtime's own words for a failed connection name addresses and
-    // internals; the reader needs to know the app was not reached, and how
-    // to check.
+    // The runtime's message names addresses and internals; keep it out.
     throw unavailable(api, undefined, "check the address and the connection, then try again");
   });
 
-  // The connection can fail after the headers as well as before them.
+  // A body can fail after the headers arrived.
   const text = await response.text().catch(() => {
     throw unavailable(api, response.status, "the answer was cut off; check the connection, then try again");
   });
@@ -207,16 +201,7 @@ export const pushCanvas = (
 ): Promise<Pushed> =>
   call(api, { method: "PUT", path: canvasPath(id), canvas: id, token, ifMatch: rev, body: document }, Pushed);
 
-/**
- * The next token is minted here and sent along, so the app's answer can be
- * lost and the same question asked again: once the token is on record, the
- * app says so whichever bearer is presented.
- */
-/**
- * Whether a token is the one on record, without changing anything: a token
- * turned over onto itself is answered "rotated" only when it is current, and
- * with the reader's 404 otherwise.
- */
+/** A rotation onto itself changes nothing and is answered "rotated" only for the current token. */
 export const verifyWriteToken = (api: string, id: string, token: string): Promise<boolean> =>
   rotateCanvas(api, id, token, token).then(
     () => true,
@@ -226,6 +211,7 @@ export const verifyWriteToken = (api: string, id: string, token: string): Promis
     },
   );
 
+/** The caller mints the next token, so a lost answer can be asked for again. */
 export const rotateCanvas = (api: string, id: string, token: string, nextToken: string): Promise<Rotated> =>
   call(
     api,

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { access, mkdir, open, readFile, rename, unlink } from "node:fs/promises";
+import { access, link, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { assertNever } from "@coldtea/pr-lens-schema";
@@ -121,12 +121,31 @@ const repositoryStanding = async (cwd: string): Promise<RepositoryStanding> => {
     await git(cwd, ["rev-parse", "--is-inside-work-tree"]);
     return "inside";
   } catch (error) {
-    if (error instanceof PrLensCliError && error.details?.includes("not a git repository")) return "outside";
+    // Git says "not a repository" about a broken checkout too, one with its
+    // HEAD missing for instance, and that checkout is repaired one day with
+    // whatever was written into it meanwhile. Only a tree with no .git
+    // anywhere above it is outside a repository.
+    const outside =
+      error instanceof PrLensCliError &&
+      error.details?.includes("not a git repository") === true &&
+      !(await hasGitAbove(cwd));
+    if (outside) return "outside";
+
     throw new PrLensCliError(
       "CANVAS_REGISTRY_EXPOSED",
       `git could not say whether ${REGISTRY_PATH} would be committed`,
       error instanceof PrLensCliError ? error.details : undefined,
     );
+  }
+};
+
+const hasGitAbove = async (start: string): Promise<boolean> => {
+  let directory = resolve(start);
+  for (;;) {
+    if (await exists(join(directory, ".git"))) return true;
+    const parent = dirname(directory);
+    if (parent === directory) return false;
+    directory = parent;
   }
 };
 
@@ -175,63 +194,54 @@ const alive = (pid: number): boolean => {
 };
 
 /**
- * Takes the lock, or nothing. The file is created exclusively and signed with
- * this holder, so nothing later removes it by path alone.
+ * Takes the lock, or nothing. The holder is written to a private file first
+ * and that file is linked into place, so the lock either exists with its
+ * holder inside or does not exist: there is no moment at which it is empty.
  */
-const takeLock = async (holder: Holder): Promise<boolean> => {
-  const handle = await open(LOCK_PATH, "wx").catch((error: unknown) => {
-    if (isAlreadyThere(error)) return undefined;
-    throw error;
-  });
-  if (handle === undefined) return false;
+const takeLock = async (mine: Holder): Promise<boolean> => {
+  const draft = `${LOCK_PATH}.${mine.nonce}`;
+  await writeFile(draft, `${mine.pid}:${mine.nonce}`, { encoding: "utf8", mode: 0o600 });
   try {
-    await handle.writeFile(`${holder.pid}:${holder.nonce}`, "utf8");
-  } finally {
-    await handle.close();
-  }
-  return true;
-};
-
-/**
- * Moves the lock aside in one step and looks at what was moved. A rename is
- * the one operation that both checks the path is there and takes it, so no
- * one else can slip a fresh lock in between; whatever was taken by mistake
- * is put straight back.
- */
-const takeAside = async (mine: Holder, expected: (holder: Holder | undefined) => boolean): Promise<boolean> => {
-  const aside = `${LOCK_PATH}.aside.${mine.nonce}`;
-  const moved = await rename(LOCK_PATH, aside).then(
-    () => true,
-    () => false,
-  );
-  if (!moved) return false;
-
-  if (expected(await readHolder(aside))) {
-    await unlink(aside).catch(() => undefined);
+    await link(draft, LOCK_PATH);
     return true;
+  } catch (error) {
+    if (isAlreadyThere(error)) return false;
+    throw error;
+  } finally {
+    await unlink(draft).catch(() => undefined);
   }
-  await rename(aside, LOCK_PATH).catch(() => undefined);
-  return false;
 };
 
-const releaseLock = (mine: Holder): Promise<boolean> =>
-  takeAside(mine, (holder) => holder?.nonce === mine.nonce);
-
 /**
- * Removes a lock whose holder is no longer running. Time is not evidence: a
- * command asleep with the machine is still a command, and it wakes up to
- * finish what it started. Only a process that is gone has given the lock up.
+ * No lock is ever taken away from another command by this code. Reclaiming
+ * a lock means deciding its holder is gone and then removing it, and those
+ * are two moments: another command can take the same path in between, and
+ * the removal then lands on a live lock. Nothing that risks two writers is
+ * worth a stale lock, which a person removes in a second once told which
+ * process left it.
  */
-const reclaimDeadLock = async (mine: Holder): Promise<void> => {
+const inUse = async (): Promise<PrLensCliError> => {
   const holder = await readHolder(LOCK_PATH);
-  if (holder === undefined || alive(holder.pid)) return;
-  await takeAside(mine, (found) => found?.pid === holder.pid && found.nonce === holder.nonce);
+  const who =
+    holder === undefined
+      ? "a command that did not finish taking it"
+      : alive(holder.pid)
+        ? `pid ${holder.pid}, which is still running`
+        : `pid ${holder.pid}, which is no longer running`;
+  return new PrLensCliError(
+    "UNREADABLE_FILE",
+    `${REGISTRY_PATH} is locked by ${who}`,
+    holder !== undefined && alive(holder.pid)
+      ? "wait for it to finish, then try again"
+      : `remove ${LOCK_PATH} and try again; nothing is running under it`,
+  );
 };
 
 /**
  * The registry is read, changed and written back as a whole, and two commands
  * doing that at once would each keep only their own change. One holds the
- * lock at a time; the other waits its turn, as long as the holder is alive.
+ * lock at a time; the other waits its turn, and gives up with the holder's
+ * name when the turn does not come.
  */
 export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> => {
   await mkdir(dirname(LOCK_PATH), { recursive: true });
@@ -242,19 +252,19 @@ export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> =>
       try {
         return await work();
       } finally {
-        await releaseLock(mine);
+        // Only this command's own lock is removed. The path cannot hold
+        // anything else while this command holds it, since nothing here
+        // takes a lock away.
+        await unlink(LOCK_PATH).catch(() => undefined);
       }
     }
-    await reclaimDeadLock(mine);
+
+    const holder = await readHolder(LOCK_PATH);
+    if (holder === undefined || !alive(holder.pid)) break;
     await sleep(LOCK_WAIT_MS);
   }
 
-  const holder = await readHolder(LOCK_PATH);
-  throw new PrLensCliError(
-    "UNREADABLE_FILE",
-    `${REGISTRY_PATH} is in use by another pr-lens command${holder === undefined ? "" : ` (pid ${holder.pid})`}`,
-    `wait for it to finish; delete ${LOCK_PATH} only if that process is not running`,
-  );
+  throw await inUse();
 };
 
 /** One change to the registry, read and written under the lock. */

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -140,11 +140,25 @@ const repositoryStanding = async (cwd: string): Promise<RepositoryStanding> => {
   }
 };
 
-/** The entry itself, not what it points at: a dangling `.git` link is still a checkout. */
+const isMissing = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && "code" in error && (error.code === "ENOENT" || error.code === "ENOTDIR");
+
+/**
+ * The entry itself, not what it points at: a dangling `.git` link is still a
+ * checkout. Only an entry that is not there counts as absent; one that cannot
+ * be looked at is a question left open, and no secret is written on one.
+ */
 const gitEntryAt = (directory: string): Promise<boolean> =>
   lstat(join(directory, ".git")).then(
     () => true,
-    () => false,
+    (error: unknown) => {
+      if (isMissing(error)) return false;
+      throw new PrLensCliError(
+        "CANVAS_REGISTRY_EXPOSED",
+        `${join(directory, ".git")} could not be looked at, so ${REGISTRY_PATH} might be committed`,
+        error instanceof Error ? error.message : String(error),
+      );
+    },
   );
 
 const hasGitAbove = async (start: string): Promise<boolean> => {

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { access, link, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { access, link, lstat, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { assertNever } from "@coldtea/pr-lens-schema";
@@ -29,7 +29,8 @@ export const mintWriteToken = (): string => randomBytes(16).toString("base64url"
 const Entry = z.object({
   name: z.string(),
   source: z.string(),
-  writeToken: z.string(),
+  /** Absent for a canvas pulled by its view link: readable, not writable, from here. */
+  writeToken: z.string().optional(),
   /**
    * A rotation in flight: minted here and sent to the app, not yet confirmed
    * as the one on record. Kept so a lost answer is finished, not lost.
@@ -139,10 +140,17 @@ const repositoryStanding = async (cwd: string): Promise<RepositoryStanding> => {
   }
 };
 
+/** The entry itself, not what it points at: a dangling `.git` link is still a checkout. */
+const gitEntryAt = (directory: string): Promise<boolean> =>
+  lstat(join(directory, ".git")).then(
+    () => true,
+    () => false,
+  );
+
 const hasGitAbove = async (start: string): Promise<boolean> => {
   let directory = resolve(start);
   for (;;) {
-    if (await exists(join(directory, ".git"))) return true;
+    if (await gitEntryAt(directory)) return true;
     const parent = dirname(directory);
     if (parent === directory) return false;
     directory = parent;
@@ -180,8 +188,17 @@ const holderOf = (text: string): Holder | undefined => {
     : undefined;
 };
 
-const readHolder = async (path: string): Promise<Holder | undefined> =>
-  readFile(path, "utf8").then(holderOf, () => undefined);
+/** What is at the lock path: nothing, a lock with a holder, or a lock nobody finished. */
+type LockState = { type: "absent" } | { type: "held"; holder: Holder } | { type: "unfinished" };
+
+const readLock = (path: string): Promise<LockState> =>
+  readFile(path, "utf8").then(
+    (text) => {
+      const holder = holderOf(text);
+      return holder === undefined ? { type: "unfinished" } : { type: "held", holder };
+    },
+    () => ({ type: "absent" }),
+  );
 
 /** Whether a process is still running here. A signal of 0 is only a question. */
 const alive = (pid: number): boolean => {
@@ -220,20 +237,26 @@ const takeLock = async (mine: Holder): Promise<boolean> => {
  * worth a stale lock, which a person removes in a second once told which
  * process left it.
  */
-const inUse = async (): Promise<PrLensCliError> => {
-  const holder = await readHolder(LOCK_PATH);
-  const who =
-    holder === undefined
-      ? "a command that did not finish taking it"
-      : alive(holder.pid)
-        ? `pid ${holder.pid}, which is still running`
-        : `pid ${holder.pid}, which is no longer running`;
+const inUse = (lock: LockState): PrLensCliError => {
+  const who = (() => {
+    switch (lock.type) {
+      case "absent":
+        return "commands taking turns faster than this one could get one";
+      case "unfinished":
+        return "a command that did not finish taking it";
+      case "held":
+        return alive(lock.holder.pid)
+          ? `pid ${lock.holder.pid}, which is still running`
+          : `pid ${lock.holder.pid}, which is no longer running`;
+      default:
+        return assertNever(lock, "Unhandled lock state");
+    }
+  })();
+  const running = lock.type === "absent" || (lock.type === "held" && alive(lock.holder.pid));
   return new PrLensCliError(
     "UNREADABLE_FILE",
     `${REGISTRY_PATH} is locked by ${who}`,
-    holder !== undefined && alive(holder.pid)
-      ? "wait for it to finish, then try again"
-      : `remove ${LOCK_PATH} and try again; nothing is running under it`,
+    running ? "wait for it to finish, then try again" : `remove ${LOCK_PATH} and try again; nothing is running under it`,
   );
 };
 
@@ -259,12 +282,23 @@ export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> =>
       }
     }
 
-    const holder = await readHolder(LOCK_PATH);
-    if (holder === undefined || !alive(holder.pid)) break;
-    await sleep(LOCK_WAIT_MS);
+    const lock = await readLock(LOCK_PATH);
+    switch (lock.type) {
+      case "absent":
+        // Released between the failed link and the look: try again at once.
+        continue;
+      case "unfinished":
+        throw inUse(lock);
+      case "held":
+        if (!alive(lock.holder.pid)) throw inUse(lock);
+        await sleep(LOCK_WAIT_MS);
+        continue;
+      default:
+        return assertNever(lock, "Unhandled lock state");
+    }
   }
 
-  throw await inUse();
+  throw inUse(await readLock(LOCK_PATH));
 };
 
 /** One change to the registry, read and written under the lock. */

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -1,7 +1,8 @@
 import { randomBytes } from "node:crypto";
-import { access, mkdir, open, readFile, rename, stat, unlink } from "node:fs/promises";
+import { access, mkdir, open, readFile, rename, unlink } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
+import { assertNever } from "@coldtea/pr-lens-schema";
 import { z } from "zod";
 import { PrLensCliError, usageError } from "../errors.js";
 import { git } from "../git.js";
@@ -72,11 +73,15 @@ export const readRegistry = async (): Promise<CanvasRegistry> => {
  */
 const assertRegistryPrivate = async (): Promise<void> => {
   const cwd = process.cwd();
-  const inRepository = await git(cwd, ["rev-parse", "--is-inside-work-tree"]).then(
-    () => true,
-    () => false,
-  );
-  if (!inRepository) return;
+  const standing = await repositoryStanding(cwd);
+  switch (standing) {
+    case "outside":
+      return;
+    case "inside":
+      break;
+    default:
+      return assertNever(standing, "Unhandled repository standing");
+  }
 
   const tracked = (await git(cwd, ["ls-files", "--", REGISTRY_PATH])).trim() !== "";
   if (tracked)
@@ -103,6 +108,28 @@ const assertRegistryPrivate = async (): Promise<void> => {
   }
 };
 
+type RepositoryStanding = "inside" | "outside";
+
+/**
+ * Whether this directory is in a git work tree. Only git's own "not a
+ * repository" is taken as being outside one; git failing for any other
+ * reason (an owner it distrusts, a broken config, a corrupt index) leaves the
+ * question open, and an open question is not permission to write a secret.
+ */
+const repositoryStanding = async (cwd: string): Promise<RepositoryStanding> => {
+  try {
+    await git(cwd, ["rev-parse", "--is-inside-work-tree"]);
+    return "inside";
+  } catch (error) {
+    if (error instanceof PrLensCliError && error.details?.includes("not a git repository")) return "outside";
+    throw new PrLensCliError(
+      "CANVAS_REGISTRY_EXPOSED",
+      `git could not say whether ${REGISTRY_PATH} would be committed`,
+      error instanceof PrLensCliError ? error.details : undefined,
+    );
+  }
+};
+
 /**
  * The workspace, ready to hold a token: on disk, ignored, and not tracked.
  * Asked before a canvas is minted, so a refusal costs nothing on the app.
@@ -117,83 +144,116 @@ export const writeRegistry = async (registry: CanvasRegistry, terminal: Terminal
   await writeSecretJsonFile(REGISTRY_PATH, registry);
 };
 
-/** A lock left by a command that died; anything this old is not a command. */
-const LOCK_STALE_MS = 30_000;
 const LOCK_WAIT_MS = 50;
 const LOCK_ATTEMPTS = 100;
 
 const isAlreadyThere = (error: unknown): boolean =>
   typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
 
+/** Who holds a lock: the process, and a nonce so two lives of one pid differ. */
+type Holder = { pid: number; nonce: string };
+
+const holderOf = (text: string): Holder | undefined => {
+  const [pid, nonce] = text.trim().split(":");
+  const number = Number(pid);
+  return Number.isInteger(number) && number > 0 && nonce !== undefined && nonce !== ""
+    ? { pid: number, nonce }
+    : undefined;
+};
+
+const readHolder = async (path: string): Promise<Holder | undefined> =>
+  readFile(path, "utf8").then(holderOf, () => undefined);
+
+/** Whether a process is still running here. A signal of 0 is only a question. */
+const alive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return typeof error === "object" && error !== null && "code" in error && error.code === "EPERM";
+  }
+};
+
 /**
  * Takes the lock, or nothing. The file is created exclusively and signed with
- * this holder's nonce, so releasing it later removes this holder's lock and
- * never one that was taken over in the meantime.
+ * this holder, so nothing later removes it by path alone.
  */
-const takeLock = async (nonce: string): Promise<boolean> => {
+const takeLock = async (holder: Holder): Promise<boolean> => {
   const handle = await open(LOCK_PATH, "wx").catch((error: unknown) => {
     if (isAlreadyThere(error)) return undefined;
     throw error;
   });
   if (handle === undefined) return false;
   try {
-    await handle.writeFile(nonce, "utf8");
+    await handle.writeFile(`${holder.pid}:${holder.nonce}`, "utf8");
   } finally {
     await handle.close();
   }
   return true;
 };
 
-const releaseLock = async (nonce: string): Promise<void> => {
-  const holder = await readFile(LOCK_PATH, "utf8").catch(() => undefined);
-  if (holder === nonce) await unlink(LOCK_PATH).catch(() => undefined);
-};
-
 /**
- * Removes a lock nobody is holding any more. The lock is moved aside first,
- * and only one of several waiters can move the same file, so a lock taken
- * afresh by another waiter in the meantime is never the one removed.
+ * Moves the lock aside in one step and looks at what was moved. A rename is
+ * the one operation that both checks the path is there and takes it, so no
+ * one else can slip a fresh lock in between; whatever was taken by mistake
+ * is put straight back.
  */
-const reclaimStaleLock = async (nonce: string): Promise<void> => {
-  const age = await stat(LOCK_PATH).then(
-    (info) => Date.now() - info.mtimeMs,
-    () => 0,
-  );
-  if (age <= LOCK_STALE_MS) return;
-
-  const aside = `${LOCK_PATH}.stale.${nonce}`;
+const takeAside = async (mine: Holder, expected: (holder: Holder | undefined) => boolean): Promise<boolean> => {
+  const aside = `${LOCK_PATH}.aside.${mine.nonce}`;
   const moved = await rename(LOCK_PATH, aside).then(
     () => true,
     () => false,
   );
-  if (moved) await unlink(aside).catch(() => undefined);
+  if (!moved) return false;
+
+  if (expected(await readHolder(aside))) {
+    await unlink(aside).catch(() => undefined);
+    return true;
+  }
+  await rename(aside, LOCK_PATH).catch(() => undefined);
+  return false;
+};
+
+const releaseLock = (mine: Holder): Promise<boolean> =>
+  takeAside(mine, (holder) => holder?.nonce === mine.nonce);
+
+/**
+ * Removes a lock whose holder is no longer running. Time is not evidence: a
+ * command asleep with the machine is still a command, and it wakes up to
+ * finish what it started. Only a process that is gone has given the lock up.
+ */
+const reclaimDeadLock = async (mine: Holder): Promise<void> => {
+  const holder = await readHolder(LOCK_PATH);
+  if (holder === undefined || alive(holder.pid)) return;
+  await takeAside(mine, (found) => found?.pid === holder.pid && found.nonce === holder.nonce);
 };
 
 /**
  * The registry is read, changed and written back as a whole, and two commands
  * doing that at once would each keep only their own change. One holds the
- * lock at a time; the other waits its turn.
+ * lock at a time; the other waits its turn, as long as the holder is alive.
  */
 export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> => {
   await mkdir(dirname(LOCK_PATH), { recursive: true });
-  const nonce = `${process.pid}.${randomBytes(8).toString("hex")}`;
+  const mine: Holder = { pid: process.pid, nonce: randomBytes(8).toString("hex") };
 
   for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt += 1) {
-    if (await takeLock(nonce)) {
+    if (await takeLock(mine)) {
       try {
         return await work();
       } finally {
-        await releaseLock(nonce);
+        await releaseLock(mine);
       }
     }
-    await reclaimStaleLock(nonce);
+    await reclaimDeadLock(mine);
     await sleep(LOCK_WAIT_MS);
   }
 
+  const holder = await readHolder(LOCK_PATH);
   throw new PrLensCliError(
     "UNREADABLE_FILE",
-    `${REGISTRY_PATH} is in use by another pr-lens command`,
-    `wait for it to finish, or delete ${LOCK_PATH} if nothing is running`,
+    `${REGISTRY_PATH} is in use by another pr-lens command${holder === undefined ? "" : ` (pid ${holder.pid})`}`,
+    `wait for it to finish; delete ${LOCK_PATH} only if that process is not running`,
   );
 };
 

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -1,15 +1,27 @@
-import { randomBytes } from "node:crypto";
-import type { Stats } from "node:fs";
-import { access, link, lstat, mkdir, readFile, realpath, stat, unlink, writeFile } from "node:fs/promises";
-import { basename, dirname, join, relative, resolve } from "node:path";
-import { setTimeout as sleep } from "node:timers/promises";
-import { assertNever } from "@coldtea/pr-lens-schema";
+import {
+  access,
+  link,
+  lstat,
+  stat,
+  mkdir,
+  unlink,
+  realpath,
+  readFile,
+  writeFile,
+} from "node:fs/promises";
 import { z } from "zod";
-import { PrLensCliError, usageError } from "../errors.js";
+import type { Stats } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { setTimeout as sleep } from "node:timers/promises";
+import { basename, dirname, join, relative, resolve } from "node:path";
+
+import { assertNever } from "@coldtea/pr-lens-schema";
+
 import { git } from "../git.js";
-import { readJsonFile, secretStagingPath, writeSecretJsonFile } from "../io.js";
 import type { Terminal } from "../terminal.js";
+import { PrLensCliError, usageError } from "../errors.js";
 import { prepareWorkspace, WORKSPACE_DIR } from "../workspace.js";
+import { readJsonFile, secretStagingPath, writeSecretJsonFile } from "../io.js";
 
 /** Holds write tokens, the one thing here nothing can rebuild. */
 export const REGISTRY_PATH = join(WORKSPACE_DIR, "canvas.json");
@@ -20,7 +32,8 @@ const CANVAS_ID = /^[A-Za-z0-9_-]{22}$/;
 
 export const isCanvasId = (value: string): boolean => CANVAS_ID.test(value);
 
-export const mintWriteToken = (): string => randomBytes(16).toString("base64url");
+export const mintWriteToken = (): string =>
+  randomBytes(16).toString("base64url");
 
 const Entry = z.object({
   name: z.string(),
@@ -34,7 +47,9 @@ const Entry = z.object({
   rev: z.number().int().nonnegative(),
 });
 
-const Registry = z.object({ canvases: z.record(z.string().regex(CANVAS_ID), Entry) });
+const Registry = z.object({
+  canvases: z.record(z.string().regex(CANVAS_ID), Entry),
+});
 
 export type CanvasEntry = z.infer<typeof Entry>;
 export type CanvasRegistry = z.infer<typeof Registry>;
@@ -54,7 +69,9 @@ export const readRegistry = async (): Promise<CanvasRegistry> => {
     throw new PrLensCliError(
       "UNREADABLE_FILE",
       `${REGISTRY_PATH} is not a canvas registry`,
-      parsed.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join("\n"),
+      parsed.error.issues
+        .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+        .join("\n"),
     );
 
   return parsed.data;
@@ -73,7 +90,9 @@ const assertRegistryPrivate = async (): Promise<void> => {
       return assertNever(standing, "Unhandled repository standing");
   }
 
-  const tracked = (await git(cwd, ["ls-files", "--", REGISTRY_PATH])).trim() !== "";
+  const tracked =
+    (await git(cwd, ["ls-files", "--", REGISTRY_PATH])).trim() !== "";
+
   if (tracked)
     throw new PrLensCliError(
       "CANVAS_REGISTRY_EXPOSED",
@@ -82,7 +101,11 @@ const assertRegistryPrivate = async (): Promise<void> => {
     );
 
   // An interrupted write leaves the tokens under the staging name.
-  for (const path of [REGISTRY_PATH, relative(cwd, secretStagingPath(REGISTRY_PATH)), LOCK_PATH]) {
+  for (const path of [
+    REGISTRY_PATH,
+    relative(cwd, secretStagingPath(REGISTRY_PATH)),
+    LOCK_PATH,
+  ]) {
     const ignored = await git(cwd, ["check-ignore", "-q", "--", path]).then(
       () => true,
       () => false,
@@ -121,7 +144,10 @@ const repositoryStanding = async (cwd: string): Promise<RepositoryStanding> => {
 };
 
 const isMissing = (error: unknown): boolean =>
-  typeof error === "object" && error !== null && "code" in error && (error.code === "ENOENT" || error.code === "ENOTDIR");
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  (error.code === "ENOENT" || error.code === "ENOTDIR");
 
 /** lstat, not stat: a dangling `.git` link is still a checkout. */
 const gitEntryAt = (directory: string): Promise<boolean> =>
@@ -153,24 +179,39 @@ export const ensureRegistryHome = async (terminal: Terminal): Promise<void> => {
   await assertRegistryPrivate();
 };
 
-const reservedRegistryPaths = (): string[] => [resolve(REGISTRY_PATH), resolve(LOCK_PATH), secretStagingPath(REGISTRY_PATH)];
+const reservedRegistryPaths = (): string[] => [
+  resolve(REGISTRY_PATH),
+  resolve(LOCK_PATH),
+  secretStagingPath(REGISTRY_PATH),
+];
 
-const sameFile = (a: Stats, b: Stats): boolean => a.dev === b.dev && a.ino === b.ino;
+const sameFile = (a: Stats, b: Stats): boolean =>
+  a.dev === b.dev && a.ino === b.ino;
 
 /** Compared case-blind and by inode: macOS ignores case, and a link is the same file. */
-export const isReservedRegistryTarget = async (path: string): Promise<boolean> => {
+export const isReservedRegistryTarget = async (
+  path: string,
+): Promise<boolean> => {
   const target = resolve(path);
   const reserved = reservedRegistryPaths();
   const names = reserved.map((entry) => basename(entry).toLowerCase());
 
   // Spelling first: a fresh checkout has nothing on disk to compare yet.
   const workspaceDir = dirname(reserved[0] ?? target);
-  if (dirname(target).toLowerCase() === workspaceDir.toLowerCase() && names.includes(basename(target).toLowerCase()))
+  if (
+    dirname(target).toLowerCase() === workspaceDir.toLowerCase() &&
+    names.includes(basename(target).toLowerCase())
+  )
     return true;
 
   const workspace = await realpath(workspaceDir).catch(() => undefined);
   const parent = await realpath(dirname(target)).catch(() => undefined);
-  if (workspace !== undefined && parent === workspace && names.includes(basename(target).toLowerCase())) return true;
+  if (
+    workspace !== undefined &&
+    parent === workspace &&
+    names.includes(basename(target).toLowerCase())
+  )
+    return true;
 
   const existing = await stat(target).catch(() => undefined);
   if (existing === undefined) return false;
@@ -181,7 +222,10 @@ export const isReservedRegistryTarget = async (path: string): Promise<boolean> =
   return false;
 };
 
-export const writeRegistry = async (registry: CanvasRegistry, terminal: Terminal): Promise<void> => {
+export const writeRegistry = async (
+  registry: CanvasRegistry,
+  terminal: Terminal,
+): Promise<void> => {
   await ensureRegistryHome(terminal);
   await writeSecretJsonFile(REGISTRY_PATH, registry);
 };
@@ -190,7 +234,10 @@ const LOCK_WAIT_MS = 50;
 const LOCK_ATTEMPTS = 100;
 
 const isAlreadyThere = (error: unknown): boolean =>
-  typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  error.code === "EEXIST";
 
 /** A nonce beside the pid, since pids are reused. */
 type Holder = { pid: number; nonce: string };
@@ -198,27 +245,39 @@ type Holder = { pid: number; nonce: string };
 const holderOf = (text: string): Holder | undefined => {
   const [pid, nonce] = text.trim().split(":");
   const number = Number(pid);
-  return Number.isInteger(number) && number > 0 && nonce !== undefined && nonce !== ""
+  return Number.isInteger(number) &&
+    number > 0 &&
+    nonce !== undefined &&
+    nonce !== ""
     ? { pid: number, nonce }
     : undefined;
 };
 
-type LockState = { type: "absent" } | { type: "held"; holder: Holder } | { type: "unfinished" };
+type LockState =
+  | { type: "absent" }
+  | { type: "held"; holder: Holder }
+  | { type: "unfinished" };
 
 const readLock = (path: string): Promise<LockState> =>
   readFile(path, "utf8").then(
     (text) => {
       const holder = holderOf(text);
-      return holder === undefined ? { type: "unfinished" } : { type: "held", holder };
+      return holder === undefined
+        ? { type: "unfinished" }
+        : { type: "held", holder };
     },
-    (error: unknown) => (isMissing(error) ? { type: "absent" } : { type: "unfinished" }),
+    (error: unknown) =>
+      isMissing(error) ? { type: "absent" } : { type: "unfinished" },
   );
 
 const cannotLock = (error: unknown): PrLensCliError =>
   new PrLensCliError(
     "UNREADABLE_FILE",
     `cannot take the lock on ${REGISTRY_PATH}`,
-    typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+    typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      typeof error.code === "string"
       ? `the filesystem answered ${error.code} for ${LOCK_PATH}`
       : `the filesystem refused ${LOCK_PATH}`,
   );
@@ -229,14 +288,22 @@ const alive = (pid: number): boolean => {
     process.kill(pid, 0);
     return true;
   } catch (error) {
-    return typeof error === "object" && error !== null && "code" in error && error.code === "EPERM";
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "EPERM"
+    );
   }
 };
 
 /** Written first, linked into place second, so the lock is never empty. */
 const takeLock = async (mine: Holder): Promise<boolean> => {
   const draft = `${LOCK_PATH}.${mine.nonce}`;
-  await writeFile(draft, `${mine.pid}:${mine.nonce}`, { encoding: "utf8", mode: 0o600 }).catch((error: unknown) => {
+  await writeFile(draft, `${mine.pid}:${mine.nonce}`, {
+    encoding: "utf8",
+    mode: 0o600,
+  }).catch((error: unknown) => {
     throw cannotLock(error);
   });
   try {
@@ -270,20 +337,31 @@ const inUse = (lock: LockState): PrLensCliError => {
         return assertNever(lock, "Unhandled lock state");
     }
   })();
-  const running = lock.type === "absent" || (lock.type === "held" && alive(lock.holder.pid));
+
+  const running =
+    lock.type === "absent" || (lock.type === "held" && alive(lock.holder.pid));
   return new PrLensCliError(
     "UNREADABLE_FILE",
     `${REGISTRY_PATH} is locked by ${who}`,
-    running ? "wait for it to finish, then try again" : `remove ${LOCK_PATH} and try again; nothing is running under it`,
+    running
+      ? "wait for it to finish, then try again"
+      : `remove ${LOCK_PATH} and try again; nothing is running under it`,
   );
 };
 
 /** Two commands writing the whole file at once would each keep only their own change. */
-export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> => {
-  await mkdir(dirname(LOCK_PATH), { recursive: true }).catch((error: unknown) => {
-    throw cannotLock(error);
-  });
-  const mine: Holder = { pid: process.pid, nonce: randomBytes(8).toString("hex") };
+export const withRegistryLock = async <T>(
+  work: () => Promise<T>,
+): Promise<T> => {
+  await mkdir(dirname(LOCK_PATH), { recursive: true }).catch(
+    (error: unknown) => {
+      throw cannotLock(error);
+    },
+  );
+  const mine: Holder = {
+    pid: process.pid,
+    nonce: randomBytes(8).toString("hex"),
+  };
 
   for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt += 1) {
     if (await takeLock(mine)) {
@@ -295,15 +373,19 @@ export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> =>
     }
 
     const lock = await readLock(LOCK_PATH);
+
     switch (lock.type) {
       case "absent":
         continue;
+
       case "unfinished":
         throw inUse(lock);
+
       case "held":
         if (!alive(lock.holder.pid)) throw inUse(lock);
         await sleep(LOCK_WAIT_MS);
         continue;
+
       default:
         return assertNever(lock, "Unhandled lock state");
     }
@@ -323,7 +405,8 @@ export const updateRegistry = (
     return registry;
   });
 
-export const sourceKey = (path: string): string => relative(process.cwd(), resolve(path));
+export const sourceKey = (path: string): string =>
+  relative(process.cwd(), resolve(path));
 
 const entries = (registry: CanvasRegistry): Registered[] =>
   Object.entries(registry.canvases).map(([id, entry]) => ({ id, entry }));
@@ -333,17 +416,22 @@ const describe = ({ id, entry }: Registered): string => `${id} (${entry.name})`;
 const unregistered = (message: string, details: string): PrLensCliError =>
   new PrLensCliError("CANVAS_UNREGISTERED", message, details);
 
-export const findCanvas = (registry: CanvasRegistry, ref: string): Registered => {
+export const findCanvas = (
+  registry: CanvasRegistry,
+  ref: string,
+): Registered => {
   const byId = registry.canvases[ref];
   if (byId !== undefined) return { id: ref, entry: byId };
 
   const byName = entries(registry).filter(({ entry }) => entry.name === ref);
   const [only, ...more] = byName;
+
   if (only === undefined)
     throw unregistered(
       `no canvas ${JSON.stringify(ref)} in ${REGISTRY_PATH}`,
       "pass the id or name of a canvas this checkout pushed, or push without --canvas to mint one",
     );
+
   if (more.length > 0)
     throw usageError(
       `${byName.length} canvases are named ${JSON.stringify(ref)}`,
@@ -353,9 +441,14 @@ export const findCanvas = (registry: CanvasRegistry, ref: string): Registered =>
   return only;
 };
 
-export const findBySource = (registry: CanvasRegistry, path: string): Registered | undefined => {
+export const findBySource = (
+  registry: CanvasRegistry,
+  path: string,
+): Registered | undefined => {
   const key = sourceKey(path);
-  const matching = entries(registry).filter(({ entry }) => sourceKey(entry.source) === key);
+  const matching = entries(registry).filter(
+    ({ entry }) => sourceKey(entry.source) === key,
+  );
   const [only, ...more] = matching;
   if (more.length > 0)
     throw unregistered(
@@ -369,11 +462,13 @@ export const findBySource = (registry: CanvasRegistry, path: string): Registered
 export const onlyCanvas = (registry: CanvasRegistry): Registered => {
   const all = entries(registry);
   const [only, ...more] = all;
+
   if (only === undefined)
     throw unregistered(
       `no canvas in ${REGISTRY_PATH}`,
       "pr-lens canvas push mints one, or pass --canvas <id|name> for one pushed elsewhere",
     );
+
   if (more.length > 0)
     throw unregistered(
       `${all.length} canvases in ${REGISTRY_PATH}`,

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -200,13 +200,18 @@ const sameFile = (a: Stats, b: Stats): boolean => a.dev === b.dev && a.ino === b
 export const isReservedRegistryTarget = async (path: string): Promise<boolean> => {
   const target = resolve(path);
   const reserved = reservedRegistryPaths();
+  const names = reserved.map((entry) => basename(entry).toLowerCase());
 
-  const workspace = await realpath(dirname(reserved[0] ?? target)).catch(() => undefined);
+  // The spelling first, before anything exists to look at: a fresh checkout
+  // has no workspace yet, and the names are reserved all the same.
+  const workspaceDir = dirname(reserved[0] ?? target);
+  if (dirname(target).toLowerCase() === workspaceDir.toLowerCase() && names.includes(basename(target).toLowerCase()))
+    return true;
+
+  // Then what the paths really are, for a workspace reached under another name.
+  const workspace = await realpath(workspaceDir).catch(() => undefined);
   const parent = await realpath(dirname(target)).catch(() => undefined);
-  if (workspace !== undefined && parent === workspace) {
-    const names = reserved.map((entry) => basename(entry).toLowerCase());
-    if (names.includes(basename(target).toLowerCase())) return true;
-  }
+  if (workspace !== undefined && parent === workspace && names.includes(basename(target).toLowerCase())) return true;
 
   const existing = await stat(target).catch(() => undefined);
   if (existing === undefined) return false;

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -25,7 +25,7 @@ export const mintWriteToken = (): string => randomBytes(16).toString("base64url"
 const Entry = z.object({
   name: z.string(),
   source: z.string(),
-  /** Another app's answers, its 404 above all, say nothing about this entry. */
+  /** Another app's 404 says nothing about this entry. */
   api: z.string(),
   /** Absent for a canvas pulled by its view link. */
   writeToken: z.string().optional(),
@@ -98,7 +98,7 @@ const assertRegistryPrivate = async (): Promise<void> => {
 
 type RepositoryStanding = "inside" | "outside";
 
-/** Any git failure but "not a repository" leaves the question open, and an open question is no permission to write a secret. */
+/** Only git's own "not a repository" means outside; any other git failure must not let a secret be written. */
 const repositoryStanding = async (cwd: string): Promise<RepositoryStanding> => {
   try {
     await git(cwd, ["rev-parse", "--is-inside-work-tree"]);
@@ -157,7 +157,7 @@ const reservedRegistryPaths = (): string[] => [resolve(REGISTRY_PATH), resolve(L
 
 const sameFile = (a: Stats, b: Stats): boolean => a.dev === b.dev && a.ino === b.ino;
 
-/** Case-blind and by inode, because spelling is not identity on the usual filesystems. */
+/** Compared case-blind and by inode: macOS ignores case, and a link is the same file. */
 export const isReservedRegistryTarget = async (path: string): Promise<boolean> => {
   const target = resolve(path);
   const reserved = reservedRegistryPaths();
@@ -259,7 +259,7 @@ const inUse = (lock: LockState): PrLensCliError => {
   const who = (() => {
     switch (lock.type) {
       case "absent":
-        return "commands taking turns faster than this one could get one";
+        return "other pr-lens commands, which kept it busy";
       case "unfinished":
         return "a command that did not finish taking it";
       case "held":

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -2,7 +2,7 @@ import { access } from "node:fs/promises";
 import { join, relative, resolve } from "node:path";
 import { z } from "zod";
 import { PrLensCliError, usageError } from "../errors.js";
-import { readJsonFile, writeJsonFile } from "../io.js";
+import { readJsonFile, writeSecretJsonFile } from "../io.js";
 import type { Terminal } from "../terminal.js";
 import { prepareWorkspace, WORKSPACE_DIR } from "../workspace.js";
 
@@ -52,7 +52,7 @@ export const readRegistry = async (): Promise<CanvasRegistry> => {
 
 export const writeRegistry = async (registry: CanvasRegistry, terminal: Terminal): Promise<void> => {
   await prepareWorkspace(WORKSPACE_DIR, terminal);
-  await writeJsonFile(REGISTRY_PATH, registry);
+  await writeSecretJsonFile(REGISTRY_PATH, registry);
 };
 
 /** The path as the registry records it, so the same file matches however it was spelled. */

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -11,11 +11,7 @@ import { readJsonFile, secretStagingPath, writeSecretJsonFile } from "../io.js";
 import type { Terminal } from "../terminal.js";
 import { prepareWorkspace, WORKSPACE_DIR } from "../workspace.js";
 
-/**
- * Which canvases this checkout has pushed, and the token each one takes. The
- * token is the only thing here that cannot be rebuilt, which is why the file
- * sits in the workspace git already ignores rather than beside the document.
- */
+/** Holds write tokens, the one thing here nothing can rebuild. */
 export const REGISTRY_PATH = join(WORKSPACE_DIR, "canvas.json");
 
 const LOCK_PATH = `${REGISTRY_PATH}.lock`;
@@ -24,23 +20,16 @@ const CANVAS_ID = /^[A-Za-z0-9_-]{22}$/;
 
 export const isCanvasId = (value: string): boolean => CANVAS_ID.test(value);
 
-/** A write token has the same shape as an id: 128 random bits as base64url. */
 export const mintWriteToken = (): string => randomBytes(16).toString("base64url");
 
 const Entry = z.object({
   name: z.string(),
   source: z.string(),
-  /**
-   * The app the canvas lives on. Everything below is only meaningful there:
-   * another app's answers, its 404 above all, say nothing about this entry.
-   */
+  /** Another app's answers, its 404 above all, say nothing about this entry. */
   api: z.string(),
-  /** Absent for a canvas pulled by its view link: readable, not writable, from here. */
+  /** Absent for a canvas pulled by its view link. */
   writeToken: z.string().optional(),
-  /**
-   * A rotation in flight: minted here and sent to the app, not yet confirmed
-   * as the one on record. Kept so a lost answer is finished, not lost.
-   */
+  /** Next token of a rotation whose answer has not arrived yet, so it can be asked again. */
   pending: z.string().optional(),
   rev: z.number().int().nonnegative(),
 });
@@ -71,13 +60,7 @@ export const readRegistry = async (): Promise<CanvasRegistry> => {
   return parsed.data;
 };
 
-/**
- * Whether git would ever take the registry. The workspace is normally ignored,
- * but a repository may un-ignore it on purpose, and a file already tracked is
- * committed whatever the rules say. A bearer token in a commit is a token
- * given to everyone with the repository, so the answer has to be no before a
- * token is written down.
- */
+/** A token in a commit is a token given to everyone with the repository. */
 const assertRegistryPrivate = async (): Promise<void> => {
   const cwd = process.cwd();
   const standing = await repositoryStanding(cwd);
@@ -98,9 +81,7 @@ const assertRegistryPrivate = async (): Promise<void> => {
       `git rm --cached ${REGISTRY_PATH}, make sure ${WORKSPACE_DIR}/ is ignored, then try again`,
     );
 
-  // The registry, the file it is staged through, and the lock beside it: a
-  // rule that covers the first alone leaves a token under the second name
-  // whenever a write is interrupted.
+  // An interrupted write leaves the tokens under the staging name.
   for (const path of [REGISTRY_PATH, relative(cwd, secretStagingPath(REGISTRY_PATH)), LOCK_PATH]) {
     const ignored = await git(cwd, ["check-ignore", "-q", "--", path]).then(
       () => true,
@@ -117,21 +98,14 @@ const assertRegistryPrivate = async (): Promise<void> => {
 
 type RepositoryStanding = "inside" | "outside";
 
-/**
- * Whether this directory is in a git work tree. Only git's own "not a
- * repository" is taken as being outside one; git failing for any other
- * reason (an owner it distrusts, a broken config, a corrupt index) leaves the
- * question open, and an open question is not permission to write a secret.
- */
+/** Any git failure but "not a repository" leaves the question open, and an open question is no permission to write a secret. */
 const repositoryStanding = async (cwd: string): Promise<RepositoryStanding> => {
   try {
     await git(cwd, ["rev-parse", "--is-inside-work-tree"]);
     return "inside";
   } catch (error) {
-    // Git says "not a repository" about a broken checkout too, one with its
-    // HEAD missing for instance, and that checkout is repaired one day with
-    // whatever was written into it meanwhile. Only a tree with no .git
-    // anywhere above it is outside a repository.
+    // Git says "not a repository" about a checkout with a missing HEAD too,
+    // and that checkout gets repaired one day.
     const outside =
       error instanceof PrLensCliError &&
       error.details?.includes("not a git repository") === true &&
@@ -149,11 +123,7 @@ const repositoryStanding = async (cwd: string): Promise<RepositoryStanding> => {
 const isMissing = (error: unknown): boolean =>
   typeof error === "object" && error !== null && "code" in error && (error.code === "ENOENT" || error.code === "ENOTDIR");
 
-/**
- * The entry itself, not what it points at: a dangling `.git` link is still a
- * checkout. Only an entry that is not there counts as absent; one that cannot
- * be looked at is a question left open, and no secret is written on one.
- */
+/** lstat, not stat: a dangling `.git` link is still a checkout. */
 const gitEntryAt = (directory: string): Promise<boolean> =>
   lstat(join(directory, ".git")).then(
     () => true,
@@ -177,38 +147,27 @@ const hasGitAbove = async (start: string): Promise<boolean> => {
   }
 };
 
-/**
- * The workspace, ready to hold a token: on disk, ignored, and not tracked.
- * Asked before a canvas is minted, so a refusal costs nothing on the app.
- */
+/** Asked before a canvas is minted, so a refusal costs nothing on the app. */
 export const ensureRegistryHome = async (terminal: Terminal): Promise<void> => {
   await prepareWorkspace(WORKSPACE_DIR, terminal);
   await assertRegistryPrivate();
 };
 
-/** The names the registry lives under, which nothing else may write to. */
 const reservedRegistryPaths = (): string[] => [resolve(REGISTRY_PATH), resolve(LOCK_PATH), secretStagingPath(REGISTRY_PATH)];
 
 const sameFile = (a: Stats, b: Stats): boolean => a.dev === b.dev && a.ino === b.ino;
 
-/**
- * Whether writing to `path` would land on the registry or one of its names.
- * Spelling is not identity: the workspace directory is compared by what it
- * really is, its files case-blind since the usual filesystems are, and an
- * existing target by inode, so a link or an alias is caught as well.
- */
+/** Case-blind and by inode, because spelling is not identity on the usual filesystems. */
 export const isReservedRegistryTarget = async (path: string): Promise<boolean> => {
   const target = resolve(path);
   const reserved = reservedRegistryPaths();
   const names = reserved.map((entry) => basename(entry).toLowerCase());
 
-  // The spelling first, before anything exists to look at: a fresh checkout
-  // has no workspace yet, and the names are reserved all the same.
+  // Spelling first: a fresh checkout has nothing on disk to compare yet.
   const workspaceDir = dirname(reserved[0] ?? target);
   if (dirname(target).toLowerCase() === workspaceDir.toLowerCase() && names.includes(basename(target).toLowerCase()))
     return true;
 
-  // Then what the paths really are, for a workspace reached under another name.
   const workspace = await realpath(workspaceDir).catch(() => undefined);
   const parent = await realpath(dirname(target)).catch(() => undefined);
   if (workspace !== undefined && parent === workspace && names.includes(basename(target).toLowerCase())) return true;
@@ -233,7 +192,7 @@ const LOCK_ATTEMPTS = 100;
 const isAlreadyThere = (error: unknown): boolean =>
   typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
 
-/** Who holds a lock: the process, and a nonce so two lives of one pid differ. */
+/** A nonce beside the pid, since pids are reused. */
 type Holder = { pid: number; nonce: string };
 
 const holderOf = (text: string): Holder | undefined => {
@@ -244,7 +203,6 @@ const holderOf = (text: string): Holder | undefined => {
     : undefined;
 };
 
-/** What is at the lock path: nothing, a lock with a holder, or a lock nobody finished. */
 type LockState = { type: "absent" } | { type: "held"; holder: Holder } | { type: "unfinished" };
 
 const readLock = (path: string): Promise<LockState> =>
@@ -256,7 +214,6 @@ const readLock = (path: string): Promise<LockState> =>
     (error: unknown) => (isMissing(error) ? { type: "absent" } : { type: "unfinished" }),
   );
 
-/** A filesystem that would not let the lock be taken, as the typed failure it is. */
 const cannotLock = (error: unknown): PrLensCliError =>
   new PrLensCliError(
     "UNREADABLE_FILE",
@@ -266,7 +223,7 @@ const cannotLock = (error: unknown): PrLensCliError =>
       : `the filesystem refused ${LOCK_PATH}`,
   );
 
-/** Whether a process is still running here. A signal of 0 is only a question. */
+/** Signal 0 only asks. */
 const alive = (pid: number): boolean => {
   try {
     process.kill(pid, 0);
@@ -276,11 +233,7 @@ const alive = (pid: number): boolean => {
   }
 };
 
-/**
- * Takes the lock, or nothing. The holder is written to a private file first
- * and that file is linked into place, so the lock either exists with its
- * holder inside or does not exist: there is no moment at which it is empty.
- */
+/** Written first, linked into place second, so the lock is never empty. */
 const takeLock = async (mine: Holder): Promise<boolean> => {
   const draft = `${LOCK_PATH}.${mine.nonce}`;
   await writeFile(draft, `${mine.pid}:${mine.nonce}`, { encoding: "utf8", mode: 0o600 }).catch((error: unknown) => {
@@ -298,12 +251,9 @@ const takeLock = async (mine: Holder): Promise<boolean> => {
 };
 
 /**
- * No lock is ever taken away from another command by this code. Reclaiming
- * a lock means deciding its holder is gone and then removing it, and those
- * are two moments: another command can take the same path in between, and
- * the removal then lands on a live lock. Nothing that risks two writers is
- * worth a stale lock, which a person removes in a second once told which
- * process left it.
+ * Nothing here ever removes another command's lock: deciding a holder is
+ * gone and removing its lock are two moments, and a live lock can slip in
+ * between. A stale lock is cheap for a person to remove once told whose it is.
  */
 const inUse = (lock: LockState): PrLensCliError => {
   const who = (() => {
@@ -328,12 +278,7 @@ const inUse = (lock: LockState): PrLensCliError => {
   );
 };
 
-/**
- * The registry is read, changed and written back as a whole, and two commands
- * doing that at once would each keep only their own change. One holds the
- * lock at a time; the other waits its turn, and gives up with the holder's
- * name when the turn does not come.
- */
+/** Two commands writing the whole file at once would each keep only their own change. */
 export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> => {
   await mkdir(dirname(LOCK_PATH), { recursive: true }).catch((error: unknown) => {
     throw cannotLock(error);
@@ -345,9 +290,6 @@ export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> =>
       try {
         return await work();
       } finally {
-        // Only this command's own lock is removed. The path cannot hold
-        // anything else while this command holds it, since nothing here
-        // takes a lock away.
         await unlink(LOCK_PATH).catch(() => undefined);
       }
     }
@@ -355,7 +297,6 @@ export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> =>
     const lock = await readLock(LOCK_PATH);
     switch (lock.type) {
       case "absent":
-        // Released between the failed link and the look: try again at once.
         continue;
       case "unfinished":
         throw inUse(lock);
@@ -371,7 +312,6 @@ export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> =>
   throw inUse(await readLock(LOCK_PATH));
 };
 
-/** One change to the registry, read and written under the lock. */
 export const updateRegistry = (
   change: (registry: CanvasRegistry) => void,
   terminal: Terminal,
@@ -383,7 +323,6 @@ export const updateRegistry = (
     return registry;
   });
 
-/** The path as the registry records it, so the same file matches however it was spelled. */
 export const sourceKey = (path: string): string => relative(process.cwd(), resolve(path));
 
 const entries = (registry: CanvasRegistry): Registered[] =>
@@ -394,7 +333,6 @@ const describe = ({ id, entry }: Registered): string => `${id} (${entry.name})`;
 const unregistered = (message: string, details: string): PrLensCliError =>
   new PrLensCliError("CANVAS_UNREGISTERED", message, details);
 
-/** An id first, then a name; a name two canvases share names neither. */
 export const findCanvas = (registry: CanvasRegistry, ref: string): Registered => {
   const byId = registry.canvases[ref];
   if (byId !== undefined) return { id: ref, entry: byId };
@@ -428,7 +366,6 @@ export const findBySource = (registry: CanvasRegistry, path: string): Registered
   return only;
 };
 
-/** The canvas a command means when nobody named one: the checkout's only one. */
 export const onlyCanvas = (registry: CanvasRegistry): Registered => {
   const all = entries(registry);
   const [only, ...more] = all;

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
-import { access, link, lstat, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
-import { dirname, join, relative, resolve } from "node:path";
+import type { Stats } from "node:fs";
+import { access, link, lstat, mkdir, readFile, realpath, stat, unlink, writeFile } from "node:fs/promises";
+import { basename, dirname, join, relative, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { assertNever } from "@coldtea/pr-lens-schema";
 import { z } from "zod";
@@ -186,11 +187,35 @@ export const ensureRegistryHome = async (terminal: Terminal): Promise<void> => {
 };
 
 /** The names the registry lives under, which nothing else may write to. */
-export const reservedRegistryPaths = (): string[] => [
-  resolve(REGISTRY_PATH),
-  resolve(LOCK_PATH),
-  secretStagingPath(REGISTRY_PATH),
-];
+const reservedRegistryPaths = (): string[] => [resolve(REGISTRY_PATH), resolve(LOCK_PATH), secretStagingPath(REGISTRY_PATH)];
+
+const sameFile = (a: Stats, b: Stats): boolean => a.dev === b.dev && a.ino === b.ino;
+
+/**
+ * Whether writing to `path` would land on the registry or one of its names.
+ * Spelling is not identity: the workspace directory is compared by what it
+ * really is, its files case-blind since the usual filesystems are, and an
+ * existing target by inode, so a link or an alias is caught as well.
+ */
+export const isReservedRegistryTarget = async (path: string): Promise<boolean> => {
+  const target = resolve(path);
+  const reserved = reservedRegistryPaths();
+
+  const workspace = await realpath(dirname(reserved[0] ?? target)).catch(() => undefined);
+  const parent = await realpath(dirname(target)).catch(() => undefined);
+  if (workspace !== undefined && parent === workspace) {
+    const names = reserved.map((entry) => basename(entry).toLowerCase());
+    if (names.includes(basename(target).toLowerCase())) return true;
+  }
+
+  const existing = await stat(target).catch(() => undefined);
+  if (existing === undefined) return false;
+  for (const entry of reserved) {
+    const kept = await stat(entry).catch(() => undefined);
+    if (kept !== undefined && sameFile(existing, kept)) return true;
+  }
+  return false;
+};
 
 export const writeRegistry = async (registry: CanvasRegistry, terminal: Terminal): Promise<void> => {
   await ensureRegistryHome(terminal);
@@ -223,7 +248,17 @@ const readLock = (path: string): Promise<LockState> =>
       const holder = holderOf(text);
       return holder === undefined ? { type: "unfinished" } : { type: "held", holder };
     },
-    () => ({ type: "absent" }),
+    (error: unknown) => (isMissing(error) ? { type: "absent" } : { type: "unfinished" }),
+  );
+
+/** A filesystem that would not let the lock be taken, as the typed failure it is. */
+const cannotLock = (error: unknown): PrLensCliError =>
+  new PrLensCliError(
+    "UNREADABLE_FILE",
+    `cannot take the lock on ${REGISTRY_PATH}`,
+    typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+      ? `the filesystem answered ${error.code} for ${LOCK_PATH}`
+      : `the filesystem refused ${LOCK_PATH}`,
   );
 
 /** Whether a process is still running here. A signal of 0 is only a question. */
@@ -243,13 +278,15 @@ const alive = (pid: number): boolean => {
  */
 const takeLock = async (mine: Holder): Promise<boolean> => {
   const draft = `${LOCK_PATH}.${mine.nonce}`;
-  await writeFile(draft, `${mine.pid}:${mine.nonce}`, { encoding: "utf8", mode: 0o600 });
+  await writeFile(draft, `${mine.pid}:${mine.nonce}`, { encoding: "utf8", mode: 0o600 }).catch((error: unknown) => {
+    throw cannotLock(error);
+  });
   try {
     await link(draft, LOCK_PATH);
     return true;
   } catch (error) {
     if (isAlreadyThere(error)) return false;
-    throw error;
+    throw cannotLock(error);
   } finally {
     await unlink(draft).catch(() => undefined);
   }
@@ -293,7 +330,9 @@ const inUse = (lock: LockState): PrLensCliError => {
  * name when the turn does not come.
  */
 export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> => {
-  await mkdir(dirname(LOCK_PATH), { recursive: true });
+  await mkdir(dirname(LOCK_PATH), { recursive: true }).catch((error: unknown) => {
+    throw cannotLock(error);
+  });
   const mine: Holder = { pid: process.pid, nonce: randomBytes(8).toString("hex") };
 
   for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt += 1) {

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -29,15 +29,18 @@ export const mintWriteToken = (): string => randomBytes(16).toString("base64url"
 const Entry = z.object({
   name: z.string(),
   source: z.string(),
+  /**
+   * The app the canvas lives on. Everything below is only meaningful there:
+   * another app's answers, its 404 above all, say nothing about this entry.
+   */
+  api: z.string(),
   /** Absent for a canvas pulled by its view link: readable, not writable, from here. */
   writeToken: z.string().optional(),
   /**
-   * A rotation in flight: minted here and sent to one app, not yet confirmed
-   * as the one on record there. Kept so a lost answer is finished, not lost,
-   * and bound to the app it was sent to, since only that app can say what
-   * became of it.
+   * A rotation in flight: minted here and sent to the app, not yet confirmed
+   * as the one on record. Kept so a lost answer is finished, not lost.
    */
-  pending: z.object({ writeToken: z.string(), api: z.string() }).optional(),
+  pending: z.string().optional(),
   rev: z.number().int().nonnegative(),
 });
 
@@ -181,6 +184,13 @@ export const ensureRegistryHome = async (terminal: Terminal): Promise<void> => {
   await prepareWorkspace(WORKSPACE_DIR, terminal);
   await assertRegistryPrivate();
 };
+
+/** The names the registry lives under, which nothing else may write to. */
+export const reservedRegistryPaths = (): string[] => [
+  resolve(REGISTRY_PATH),
+  resolve(LOCK_PATH),
+  secretStagingPath(REGISTRY_PATH),
+];
 
 export const writeRegistry = async (registry: CanvasRegistry, terminal: Terminal): Promise<void> => {
   await ensureRegistryHome(terminal);

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -1,11 +1,11 @@
 import { randomBytes } from "node:crypto";
-import { access, mkdir, open, stat, unlink } from "node:fs/promises";
+import { access, mkdir, open, readFile, rename, stat, unlink } from "node:fs/promises";
 import { dirname, join, relative, resolve } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { z } from "zod";
 import { PrLensCliError, usageError } from "../errors.js";
 import { git } from "../git.js";
-import { readJsonFile, writeSecretJsonFile } from "../io.js";
+import { readJsonFile, secretStagingPath, writeSecretJsonFile } from "../io.js";
 import type { Terminal } from "../terminal.js";
 import { prepareWorkspace, WORKSPACE_DIR } from "../workspace.js";
 
@@ -15,6 +15,8 @@ import { prepareWorkspace, WORKSPACE_DIR } from "../workspace.js";
  * sits in the workspace git already ignores rather than beside the document.
  */
 export const REGISTRY_PATH = join(WORKSPACE_DIR, "canvas.json");
+
+const LOCK_PATH = `${REGISTRY_PATH}.lock`;
 
 const CANVAS_ID = /^[A-Za-z0-9_-]{22}$/;
 
@@ -84,16 +86,21 @@ const assertRegistryPrivate = async (): Promise<void> => {
       `git rm --cached ${REGISTRY_PATH}, make sure ${WORKSPACE_DIR}/ is ignored, then try again`,
     );
 
-  const ignored = await git(cwd, ["check-ignore", "-q", "--", REGISTRY_PATH]).then(
-    () => true,
-    () => false,
-  );
-  if (!ignored)
-    throw new PrLensCliError(
-      "CANVAS_REGISTRY_EXPOSED",
-      `${REGISTRY_PATH} is not ignored by git, and it holds write tokens`,
-      `ignore ${WORKSPACE_DIR}/ or ${REGISTRY_PATH} in .gitignore, then try again`,
+  // The registry, the file it is staged through, and the lock beside it: a
+  // rule that covers the first alone leaves a token under the second name
+  // whenever a write is interrupted.
+  for (const path of [REGISTRY_PATH, relative(cwd, secretStagingPath(REGISTRY_PATH)), LOCK_PATH]) {
+    const ignored = await git(cwd, ["check-ignore", "-q", "--", path]).then(
+      () => true,
+      () => false,
     );
+    if (!ignored)
+      throw new PrLensCliError(
+        "CANVAS_REGISTRY_EXPOSED",
+        `${path} is not ignored by git, and ${REGISTRY_PATH} holds write tokens`,
+        `ignore the whole ${WORKSPACE_DIR}/ directory in .gitignore, then try again`,
+      );
+  }
 };
 
 /**
@@ -110,8 +117,6 @@ export const writeRegistry = async (registry: CanvasRegistry, terminal: Terminal
   await writeSecretJsonFile(REGISTRY_PATH, registry);
 };
 
-const LOCK_PATH = `${REGISTRY_PATH}.lock`;
-
 /** A lock left by a command that died; anything this old is not a command. */
 const LOCK_STALE_MS = 30_000;
 const LOCK_WAIT_MS = 50;
@@ -121,36 +126,67 @@ const isAlreadyThere = (error: unknown): boolean =>
   typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
 
 /**
+ * Takes the lock, or nothing. The file is created exclusively and signed with
+ * this holder's nonce, so releasing it later removes this holder's lock and
+ * never one that was taken over in the meantime.
+ */
+const takeLock = async (nonce: string): Promise<boolean> => {
+  const handle = await open(LOCK_PATH, "wx").catch((error: unknown) => {
+    if (isAlreadyThere(error)) return undefined;
+    throw error;
+  });
+  if (handle === undefined) return false;
+  try {
+    await handle.writeFile(nonce, "utf8");
+  } finally {
+    await handle.close();
+  }
+  return true;
+};
+
+const releaseLock = async (nonce: string): Promise<void> => {
+  const holder = await readFile(LOCK_PATH, "utf8").catch(() => undefined);
+  if (holder === nonce) await unlink(LOCK_PATH).catch(() => undefined);
+};
+
+/**
+ * Removes a lock nobody is holding any more. The lock is moved aside first,
+ * and only one of several waiters can move the same file, so a lock taken
+ * afresh by another waiter in the meantime is never the one removed.
+ */
+const reclaimStaleLock = async (nonce: string): Promise<void> => {
+  const age = await stat(LOCK_PATH).then(
+    (info) => Date.now() - info.mtimeMs,
+    () => 0,
+  );
+  if (age <= LOCK_STALE_MS) return;
+
+  const aside = `${LOCK_PATH}.stale.${nonce}`;
+  const moved = await rename(LOCK_PATH, aside).then(
+    () => true,
+    () => false,
+  );
+  if (moved) await unlink(aside).catch(() => undefined);
+};
+
+/**
  * The registry is read, changed and written back as a whole, and two commands
  * doing that at once would each keep only their own change. One holds the
  * lock at a time; the other waits its turn.
  */
 export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> => {
   await mkdir(dirname(LOCK_PATH), { recursive: true });
+  const nonce = `${process.pid}.${randomBytes(8).toString("hex")}`;
 
   for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt += 1) {
-    const handle = await open(LOCK_PATH, "wx").catch((error: unknown) => {
-      if (isAlreadyThere(error)) return undefined;
-      throw error;
-    });
-
-    if (handle !== undefined) {
-      await handle.close();
+    if (await takeLock(nonce)) {
       try {
         return await work();
       } finally {
-        await unlink(LOCK_PATH).catch(() => undefined);
+        await releaseLock(nonce);
       }
     }
-
-    const age = await stat(LOCK_PATH).then(
-      (info) => Date.now() - info.mtimeMs,
-      () => 0,
-    );
-    if (age > LOCK_STALE_MS) {
-      await unlink(LOCK_PATH).catch(() => undefined);
-      continue;
-    }
+    await reclaimStaleLock(nonce);
     await sleep(LOCK_WAIT_MS);
   }
 

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -1,0 +1,119 @@
+import { access } from "node:fs/promises";
+import { join, relative, resolve } from "node:path";
+import { z } from "zod";
+import { PrLensCliError, usageError } from "../errors.js";
+import { readJsonFile, writeJsonFile } from "../io.js";
+import type { Terminal } from "../terminal.js";
+import { prepareWorkspace, WORKSPACE_DIR } from "../workspace.js";
+
+/**
+ * Which canvases this checkout has pushed, and the token each one takes. The
+ * token is the only thing here that cannot be rebuilt, which is why the file
+ * sits in the workspace git already ignores rather than beside the document.
+ */
+export const REGISTRY_PATH = join(WORKSPACE_DIR, "canvas.json");
+
+const CANVAS_ID = /^[A-Za-z0-9_-]{22}$/;
+
+export const isCanvasId = (value: string): boolean => CANVAS_ID.test(value);
+
+const Entry = z.object({
+  name: z.string(),
+  source: z.string(),
+  writeToken: z.string(),
+  rev: z.number().int().nonnegative(),
+});
+
+const Registry = z.object({ canvases: z.record(z.string().regex(CANVAS_ID), Entry) });
+
+export type CanvasEntry = z.infer<typeof Entry>;
+export type CanvasRegistry = z.infer<typeof Registry>;
+export type Registered = { id: string; entry: CanvasEntry };
+
+const exists = (path: string): Promise<boolean> =>
+  access(path).then(
+    () => true,
+    () => false,
+  );
+
+export const readRegistry = async (): Promise<CanvasRegistry> => {
+  if (!(await exists(REGISTRY_PATH))) return { canvases: {} };
+
+  const parsed = Registry.safeParse(await readJsonFile(REGISTRY_PATH));
+  if (!parsed.success)
+    throw new PrLensCliError(
+      "UNREADABLE_FILE",
+      `${REGISTRY_PATH} is not a canvas registry`,
+      parsed.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`).join("\n"),
+    );
+
+  return parsed.data;
+};
+
+export const writeRegistry = async (registry: CanvasRegistry, terminal: Terminal): Promise<void> => {
+  await prepareWorkspace(WORKSPACE_DIR, terminal);
+  await writeJsonFile(REGISTRY_PATH, registry);
+};
+
+/** The path as the registry records it, so the same file matches however it was spelled. */
+export const sourceKey = (path: string): string => relative(process.cwd(), resolve(path));
+
+const entries = (registry: CanvasRegistry): Registered[] =>
+  Object.entries(registry.canvases).map(([id, entry]) => ({ id, entry }));
+
+const describe = ({ id, entry }: Registered): string => `${id} (${entry.name})`;
+
+const unregistered = (message: string, details: string): PrLensCliError =>
+  new PrLensCliError("CANVAS_UNREGISTERED", message, details);
+
+/** An id first, then a name; a name two canvases share names neither. */
+export const findCanvas = (registry: CanvasRegistry, ref: string): Registered => {
+  const byId = registry.canvases[ref];
+  if (byId !== undefined) return { id: ref, entry: byId };
+
+  const byName = entries(registry).filter(({ entry }) => entry.name === ref);
+  const [only, ...more] = byName;
+  if (only === undefined)
+    throw unregistered(
+      `no canvas ${JSON.stringify(ref)} in ${REGISTRY_PATH}`,
+      "pass the id or name of a canvas this checkout pushed, or push without --canvas to mint one",
+    );
+  if (more.length > 0)
+    throw usageError(
+      `${byName.length} canvases are named ${JSON.stringify(ref)}`,
+      `pass an id instead: ${byName.map(describe).join(", ")}`,
+    );
+
+  return only;
+};
+
+export const findBySource = (registry: CanvasRegistry, path: string): Registered | undefined => {
+  const key = sourceKey(path);
+  const matching = entries(registry).filter(({ entry }) => sourceKey(entry.source) === key);
+  const [only, ...more] = matching;
+  if (more.length > 0)
+    throw unregistered(
+      `${matching.length} canvases were pushed from ${key}`,
+      `pass --canvas <id|name>: ${matching.map(describe).join(", ")}`,
+    );
+
+  return only;
+};
+
+/** The canvas a command means when nobody named one: the checkout's only one. */
+export const onlyCanvas = (registry: CanvasRegistry): Registered => {
+  const all = entries(registry);
+  const [only, ...more] = all;
+  if (only === undefined)
+    throw unregistered(
+      `no canvas in ${REGISTRY_PATH}`,
+      "pr-lens canvas push mints one, or pass --canvas <id|name> for one pushed elsewhere",
+    );
+  if (more.length > 0)
+    throw unregistered(
+      `${all.length} canvases in ${REGISTRY_PATH}`,
+      `pass --canvas <id|name>: ${all.map(describe).join(", ")}`,
+    );
+
+  return only;
+};

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -32,10 +32,12 @@ const Entry = z.object({
   /** Absent for a canvas pulled by its view link: readable, not writable, from here. */
   writeToken: z.string().optional(),
   /**
-   * A rotation in flight: minted here and sent to the app, not yet confirmed
-   * as the one on record. Kept so a lost answer is finished, not lost.
+   * A rotation in flight: minted here and sent to one app, not yet confirmed
+   * as the one on record there. Kept so a lost answer is finished, not lost,
+   * and bound to the app it was sent to, since only that app can say what
+   * became of it.
    */
-  nextWriteToken: z.string().optional(),
+  pending: z.object({ writeToken: z.string(), api: z.string() }).optional(),
   rev: z.number().int().nonnegative(),
 });
 

--- a/packages/cli/src/canvas/registry.ts
+++ b/packages/cli/src/canvas/registry.ts
@@ -1,7 +1,10 @@
-import { access } from "node:fs/promises";
-import { join, relative, resolve } from "node:path";
+import { randomBytes } from "node:crypto";
+import { access, mkdir, open, stat, unlink } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import { z } from "zod";
 import { PrLensCliError, usageError } from "../errors.js";
+import { git } from "../git.js";
 import { readJsonFile, writeSecretJsonFile } from "../io.js";
 import type { Terminal } from "../terminal.js";
 import { prepareWorkspace, WORKSPACE_DIR } from "../workspace.js";
@@ -17,10 +20,18 @@ const CANVAS_ID = /^[A-Za-z0-9_-]{22}$/;
 
 export const isCanvasId = (value: string): boolean => CANVAS_ID.test(value);
 
+/** A write token has the same shape as an id: 128 random bits as base64url. */
+export const mintWriteToken = (): string => randomBytes(16).toString("base64url");
+
 const Entry = z.object({
   name: z.string(),
   source: z.string(),
   writeToken: z.string(),
+  /**
+   * A rotation in flight: minted here and sent to the app, not yet confirmed
+   * as the one on record. Kept so a lost answer is finished, not lost.
+   */
+  nextWriteToken: z.string().optional(),
   rev: z.number().int().nonnegative(),
 });
 
@@ -50,10 +61,117 @@ export const readRegistry = async (): Promise<CanvasRegistry> => {
   return parsed.data;
 };
 
-export const writeRegistry = async (registry: CanvasRegistry, terminal: Terminal): Promise<void> => {
+/**
+ * Whether git would ever take the registry. The workspace is normally ignored,
+ * but a repository may un-ignore it on purpose, and a file already tracked is
+ * committed whatever the rules say. A bearer token in a commit is a token
+ * given to everyone with the repository, so the answer has to be no before a
+ * token is written down.
+ */
+const assertRegistryPrivate = async (): Promise<void> => {
+  const cwd = process.cwd();
+  const inRepository = await git(cwd, ["rev-parse", "--is-inside-work-tree"]).then(
+    () => true,
+    () => false,
+  );
+  if (!inRepository) return;
+
+  const tracked = (await git(cwd, ["ls-files", "--", REGISTRY_PATH])).trim() !== "";
+  if (tracked)
+    throw new PrLensCliError(
+      "CANVAS_REGISTRY_EXPOSED",
+      `${REGISTRY_PATH} is tracked by git, and it holds write tokens`,
+      `git rm --cached ${REGISTRY_PATH}, make sure ${WORKSPACE_DIR}/ is ignored, then try again`,
+    );
+
+  const ignored = await git(cwd, ["check-ignore", "-q", "--", REGISTRY_PATH]).then(
+    () => true,
+    () => false,
+  );
+  if (!ignored)
+    throw new PrLensCliError(
+      "CANVAS_REGISTRY_EXPOSED",
+      `${REGISTRY_PATH} is not ignored by git, and it holds write tokens`,
+      `ignore ${WORKSPACE_DIR}/ or ${REGISTRY_PATH} in .gitignore, then try again`,
+    );
+};
+
+/**
+ * The workspace, ready to hold a token: on disk, ignored, and not tracked.
+ * Asked before a canvas is minted, so a refusal costs nothing on the app.
+ */
+export const ensureRegistryHome = async (terminal: Terminal): Promise<void> => {
   await prepareWorkspace(WORKSPACE_DIR, terminal);
+  await assertRegistryPrivate();
+};
+
+export const writeRegistry = async (registry: CanvasRegistry, terminal: Terminal): Promise<void> => {
+  await ensureRegistryHome(terminal);
   await writeSecretJsonFile(REGISTRY_PATH, registry);
 };
+
+const LOCK_PATH = `${REGISTRY_PATH}.lock`;
+
+/** A lock left by a command that died; anything this old is not a command. */
+const LOCK_STALE_MS = 30_000;
+const LOCK_WAIT_MS = 50;
+const LOCK_ATTEMPTS = 100;
+
+const isAlreadyThere = (error: unknown): boolean =>
+  typeof error === "object" && error !== null && "code" in error && error.code === "EEXIST";
+
+/**
+ * The registry is read, changed and written back as a whole, and two commands
+ * doing that at once would each keep only their own change. One holds the
+ * lock at a time; the other waits its turn.
+ */
+export const withRegistryLock = async <T>(work: () => Promise<T>): Promise<T> => {
+  await mkdir(dirname(LOCK_PATH), { recursive: true });
+
+  for (let attempt = 0; attempt < LOCK_ATTEMPTS; attempt += 1) {
+    const handle = await open(LOCK_PATH, "wx").catch((error: unknown) => {
+      if (isAlreadyThere(error)) return undefined;
+      throw error;
+    });
+
+    if (handle !== undefined) {
+      await handle.close();
+      try {
+        return await work();
+      } finally {
+        await unlink(LOCK_PATH).catch(() => undefined);
+      }
+    }
+
+    const age = await stat(LOCK_PATH).then(
+      (info) => Date.now() - info.mtimeMs,
+      () => 0,
+    );
+    if (age > LOCK_STALE_MS) {
+      await unlink(LOCK_PATH).catch(() => undefined);
+      continue;
+    }
+    await sleep(LOCK_WAIT_MS);
+  }
+
+  throw new PrLensCliError(
+    "UNREADABLE_FILE",
+    `${REGISTRY_PATH} is in use by another pr-lens command`,
+    `wait for it to finish, or delete ${LOCK_PATH} if nothing is running`,
+  );
+};
+
+/** One change to the registry, read and written under the lock. */
+export const updateRegistry = (
+  change: (registry: CanvasRegistry) => void,
+  terminal: Terminal,
+): Promise<CanvasRegistry> =>
+  withRegistryLock(async () => {
+    const registry = await readRegistry();
+    change(registry);
+    await writeRegistry(registry, terminal);
+    return registry;
+  });
 
 /** The path as the registry records it, so the same file matches however it was spelled. */
 export const sourceKey = (path: string): string => relative(process.cwd(), resolve(path));

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,6 @@
 import { assertNever } from "@coldtea/pr-lens-schema";
 import { analyzeCommand, USAGE as ANALYZE_USAGE } from "./commands/analyze.js";
+import { canvasCommand, USAGE as CANVAS_USAGE } from "./commands/canvas.js";
 import { commentCommand, USAGE as COMMENT_USAGE } from "./commands/comment.js";
 import { exportCommand, USAGE as EXPORT_USAGE } from "./commands/export.js";
 import { renderCommand, USAGE as RENDER_USAGE } from "./commands/render.js";
@@ -8,7 +9,7 @@ import { formatError, PrLensCliError } from "./errors.js";
 import type { Terminal } from "./terminal.js";
 import { CLI_VERSION } from "./version.js";
 
-const COMMANDS = ["analyze", "render", "comment", "validate", "export"] as const;
+const COMMANDS = ["analyze", "render", "comment", "validate", "export", "canvas"] as const;
 type CommandName = (typeof COMMANDS)[number];
 
 const isCommand = (value: string): value is CommandName =>
@@ -21,6 +22,7 @@ const HELP = `pr-lens — review what actually matters
   pr-lens comment   --graph --manifest      the pull request comment, as markdown
   pr-lens validate  <file...>               any PR Lens document, checked against the contract
   pr-lens export    <graph.json>            the merged state, as a map worth committing
+  pr-lens canvas    push | pull | rotate    that document, kept on prlens.dev as a page and an embed
 
   pr-lens <command> --help                  what a command takes
   pr-lens --version
@@ -40,6 +42,8 @@ const usageFor = (command: CommandName): string => {
       return VALIDATE_USAGE;
     case "export":
       return EXPORT_USAGE;
+    case "canvas":
+      return CANVAS_USAGE;
     default:
       return assertNever(command, "Unhandled command");
   }
@@ -62,6 +66,8 @@ const dispatch = (
       return validateCommand(args, terminal);
     case "export":
       return exportCommand(args, terminal);
+    case "canvas":
+      return canvasCommand(args, terminal, env);
     default:
       return assertNever(command, "Unhandled command");
   }

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -140,8 +140,8 @@ const settleRotation = async (
       // later would carry it out.
       await updateRegistry((registry) => {
         const current = registry.canvases[id];
-        if (current === undefined || current.nextWriteToken !== nextToken) return;
-        registry.canvases[id] = { ...current, nextWriteToken: undefined };
+        if (current?.pending?.writeToken !== nextToken || current.pending.api !== api) return;
+        registry.canvases[id] = { ...current, pending: undefined };
       }, terminal);
       throw new PrLensCliError(
         error.code,
@@ -155,14 +155,25 @@ const settleRotation = async (
   // to a later rotation, which will close its own.
   await updateRegistry((registry) => {
     const current = registry.canvases[id];
-    if (current === undefined || current.nextWriteToken !== nextToken) return;
-    registry.canvases[id] = { ...current, writeToken: nextToken, nextWriteToken: undefined };
+    if (current?.pending?.writeToken !== nextToken || current.pending.api !== api) return;
+    registry.canvases[id] = { ...current, writeToken: nextToken, pending: undefined };
   }, terminal);
 
   return {
-    registered: { id, entry: { ...entry, writeToken: nextToken, nextWriteToken: undefined } },
+    registered: { id, entry: { ...entry, writeToken: nextToken, pending: undefined } },
     editUrl: rotated.editUrl,
   };
+};
+
+/**
+ * A rotation pending against another app is that app's to finish. Here it
+ * is neither carried out nor dropped: this app's answers say nothing about
+ * it. The stored token is used, and the reader is told.
+ */
+const pendingElsewhere = (api: string, { id, entry }: Registered, terminal: Terminal): boolean => {
+  if (entry.pending === undefined || entry.pending.api === api) return false;
+  terminal.err(`  a rotation of ${id} is still pending against ${entry.pending.api}; run pr-lens canvas rotate --api ${entry.pending.api} to finish it`);
+  return true;
 };
 
 const push = async (
@@ -210,9 +221,11 @@ const push = async (
       return { id: minted.id, entry };
     }));
 
-  const pending = registered.entry.nextWriteToken;
+  const pending = registered.entry.pending;
   const target =
-    pending === undefined ? registered : (await settleRotation(api, registered, pending, terminal)).registered;
+    pending === undefined || pendingElsewhere(api, registered, terminal)
+      ? registered
+      : (await settleRotation(api, registered, pending.writeToken, terminal)).registered;
 
   const pushed = await pushCanvas(api, target.id, requireWriteToken(target), target.entry.rev, document);
 
@@ -276,11 +289,11 @@ const pull = async (
     outcome.recorded =
       imports ? "imported" : proven && !untouched ? "overtaken" : writeToken !== undefined && !proven ? "refused" : "kept";
     const kept = imports ? writeToken : entry?.writeToken;
-    const pending = imports ? undefined : entry?.nextWriteToken;
+    const pending = imports ? undefined : entry?.pending;
     current.canvases[id] = {
       name: entry?.name ?? fetched.document.title,
       source: entry?.source ?? sourceKey(out),
-      ...(pending === undefined ? {} : { nextWriteToken: pending }),
+      ...(pending === undefined ? {} : { pending }),
       ...(kept === undefined ? {} : { writeToken: kept }),
       rev: fetched.rev,
     };
@@ -333,14 +346,20 @@ const rotate = async (
     // out by the next push once a pen arrives, retiring the very link that
     // brought it.
     requireWriteToken({ id, entry });
-    const nextWriteToken = entry.nextWriteToken ?? mintWriteToken();
-    pending = { id, entry: { ...entry, nextWriteToken } };
+    if (entry.pending !== undefined && entry.pending.api !== api)
+      throw new PrLensCliError(
+        "CANVAS_UNREGISTERED",
+        `a rotation of ${id} is still pending against ${entry.pending.api}`,
+        `finish it there first: pr-lens canvas rotate --api ${entry.pending.api}`,
+      );
+    const writeToken = entry.pending?.writeToken ?? mintWriteToken();
+    pending = { id, entry: { ...entry, pending: { writeToken, api } } };
     current.canvases[id] = pending.entry;
   }, terminal);
-  if (pending === undefined || pending.entry.nextWriteToken === undefined)
+  if (pending === undefined || pending.entry.pending === undefined)
     throw new PrLensCliError("CANVAS_UNREGISTERED", `${id} is no longer in ${REGISTRY_PATH}`);
 
-  const { editUrl } = await settleRotation(api, pending, pending.entry.nextWriteToken, terminal);
+  const { editUrl } = await settleRotation(api, pending, pending.entry.pending.writeToken, terminal);
 
   const view = new URL(editUrl);
   view.hash = "";

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -115,7 +115,7 @@ const readCanvasRef = (value: string): CanvasRef => {
   return { id, origin: url.origin, writeToken };
 };
 
-/** Another app's 404 means nothing about this entry, and acting on it would. */
+/** Another app's 404 says nothing about this entry, so it must not change it. */
 const requireSameApi = (api: string, { id, entry }: Registered): void => {
   if (entry.api === api) return;
   throw new PrLensCliError(
@@ -165,8 +165,8 @@ const settleRotation = async (
     if (!(error instanceof PrLensCliError)) throw error;
     if (error.code !== "CANVAS_UNKNOWN") throw unfinishedRotation(error);
 
-    // Conclusive, since a current pending token would have been answered
-    // "rotated". Dropped here, or a token imported later would carry it out.
+    // Final: a pending token that was current would have been answered
+    // "rotated". Drop it now, or a token imported later would carry it out.
     await updateRegistry((registry) => {
       const current = registry.canvases[id];
       if (
@@ -179,7 +179,7 @@ const settleRotation = async (
     }, terminal);
     throw new PrLensCliError(
       error.code,
-      `${error.message}; the rotation that was pending has been dropped`,
+      `${error.message}; the pending rotation was dropped`,
       error.details,
     );
   });
@@ -488,8 +488,8 @@ const rotate = async (
   const { id } =
     ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref);
 
-  // Written down before the app hears of it, so a lost answer cannot lose
-  // it; chosen under the lock, so two rotations at once finish the same one.
+  // Saved before the request, so a lost answer cannot lose it; chosen under
+  // the lock, so two rotations at once finish the same one.
   let pending: Registered | undefined;
   await updateRegistry((current) => {
     const entry = current.canvases[id];

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -9,9 +9,9 @@ import {
   isCanvasId,
   mintWriteToken,
   onlyCanvas,
+  isReservedRegistryTarget,
   readRegistry,
   REGISTRY_PATH,
-  reservedRegistryPaths,
   sourceKey,
   updateRegistry,
   withRegistryLock,
@@ -180,6 +180,26 @@ const settleRotation = async (
   };
 };
 
+/** An edit link for a canvas nobody has pushed to: registered at rev 0, the way a mint is. */
+const registerUnpushed = (
+  api: string,
+  id: string,
+  writeToken: string,
+  seenToken: string | undefined,
+  terminal: Terminal,
+): Promise<unknown> =>
+  updateRegistry((current) => {
+    const entry = current.canvases[id];
+    if (entry !== undefined && (entry.api !== api || entry.writeToken !== seenToken)) return;
+    current.canvases[id] = {
+      name: entry?.name ?? id,
+      source: entry?.source ?? DEFAULT_SOURCE,
+      api,
+      writeToken,
+      rev: entry?.rev ?? 0,
+    };
+  }, terminal);
+
 const push = async (
   args: readonly string[],
   terminal: Terminal,
@@ -284,18 +304,30 @@ const pull = async (
   const explicit = readString(values.api, "api");
   const api = explicit === undefined && origin !== undefined ? origin : readApi(explicit, env);
   const out = readString(values.out, "out") ?? DEFAULT_OUT;
-  if (reservedRegistryPaths().includes(resolve(out)))
+  if (await isReservedRegistryTarget(out))
     throw usageError(`${out} is where the write tokens live; a document cannot be written there`);
-
-  const fetched = await fetchCanvas(api, id);
-  await writeJsonFile(out, fetched.document);
 
   // An edit link's token is proven before it is written down: an old
   // bookmark from before a rotation must not replace the token that works.
   // The proof is about the entry as it was read; if another command changes
-  // the entry in the meantime, the proof is stale and is not acted on.
+  // the entry in the meantime, the proof is stale and is not acted on. It
+  // comes before the fetch because a canvas nobody has pushed to yet has
+  // nothing to fetch, and its edit link is still worth registering.
   const seenToken = registry.canvases[id]?.writeToken;
   const proven = writeToken !== undefined && (await verifyWriteToken(api, id, writeToken));
+
+  const fetched = await fetchCanvas(api, id).catch(async (error: unknown) => {
+    if (!(error instanceof PrLensCliError) || error.code !== "CANVAS_UNKNOWN" || !proven) throw error;
+    // Minted and never pushed: the app shows nothing yet, but the pen is
+    // real, and recording it is the whole point of pulling an edit link.
+    await registerUnpushed(api, id, writeToken, seenToken, terminal);
+    return undefined;
+  });
+  if (fetched === undefined) {
+    terminal.out(`✓ ${id} has nothing pushed to it yet; its token is now in ${REGISTRY_PATH}`);
+    return;
+  }
+  await writeJsonFile(out, fetched.document);
 
   type Recorded = "imported" | "kept" | "overtaken" | "refused" | "elsewhere";
   const outcome: { recorded: Recorded } = { recorded: "kept" };

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -1,5 +1,4 @@
 import { assertNever } from "@coldtea/pr-lens-schema";
-import { resolve } from "node:path";
 import { parseOptions, readString } from "../args.js";
 import {
   fetchCanvas,
@@ -234,8 +233,10 @@ const recordPull = (current: CanvasRegistry, pull: PullRecord): Recorded => {
   const untouched = entry?.writeToken === pull.seenToken;
   const imports =
     pull.proven && untouched && pull.writeToken !== entry?.writeToken;
+
   const kept = imports ? pull.writeToken : entry?.writeToken;
   const pending = imports ? undefined : entry?.pending;
+
   current.canvases[pull.id] = {
     name: entry?.name ?? pull.fetched?.title ?? pull.id,
     source:
@@ -333,6 +334,7 @@ const push = async (
         rev: minted.rev,
       };
       current.canvases[minted.id] = entry;
+
       try {
         await writeRegistry(current, terminal);
       } catch (error) {

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -12,6 +12,9 @@ import {
   REGISTRY_PATH,
   sourceKey,
   updateRegistry,
+  withRegistryLock,
+  writeRegistry,
+  type CanvasEntry,
   type Registered,
 } from "../canvas/registry.js";
 import { readGraphDoc } from "../document.js";
@@ -62,9 +65,18 @@ const readApi = (value: unknown, env: Record<string, string | undefined>): strin
   return api.replace(/\/+$/, "");
 };
 
-/** A bare id, or the view link a page shows: {api}/c/{id}, fragment and all. */
-const readCanvasRef = (value: string): { id: string; origin: string | undefined } => {
-  if (isCanvasId(value)) return { id: value, origin: undefined };
+type CanvasRef = { id: string; origin: string | undefined; writeToken: string | undefined };
+
+/** What a token in a fragment may be spelled with; anything else is not one. */
+const TOKEN_SHAPE = /^[A-Za-z0-9_-]+$/;
+
+/**
+ * A bare id, or a link a page shows: {app}/c/{id}. An edit link carries the
+ * write token in its fragment, and pulling one is how a checkout that never
+ * pushed the canvas comes to hold its pen.
+ */
+const readCanvasRef = (value: string): CanvasRef => {
+  if (isCanvasId(value)) return { id: value, origin: undefined, writeToken: undefined };
 
   const url = (() => {
     try {
@@ -78,7 +90,20 @@ const readCanvasRef = (value: string): { id: string; origin: string | undefined 
   const id = last?.replace(/\.svg$/, "");
   if (c !== "c" || id === undefined || deeper.length > 0 || !isCanvasId(id))
     throw usageError(`${value} is not a canvas URL`, "expected {app}/c/{id}");
-  return { id, origin: url.origin };
+
+  const fragment = new URLSearchParams(url.hash.replace(/^#/, ""));
+  const writeToken = fragment.get("w") ?? undefined;
+  return { id, origin: url.origin, writeToken: writeToken !== undefined && TOKEN_SHAPE.test(writeToken) ? writeToken : undefined };
+};
+
+/** The pen for a canvas, or the way to get one. */
+const requireWriteToken = ({ id, entry }: Registered): string => {
+  if (entry.writeToken !== undefined) return entry.writeToken;
+  throw new PrLensCliError(
+    "CANVAS_UNREGISTERED",
+    `this checkout can read ${id} but holds no write token for it`,
+    "pull its edit link, the one with #w= at the end, and the token comes with it",
+  );
 };
 
 const countDiagrams = (count: number): string => `${count} ${count === 1 ? "diagram" : "diagrams"}`;
@@ -102,7 +127,7 @@ const settleRotation = async (
   nextToken: string,
   terminal: Terminal,
 ): Promise<{ registered: Registered; editUrl: string }> => {
-  const rotated = await rotateCanvas(api, id, entry.writeToken, nextToken).catch((error: unknown) => {
+  const rotated = await rotateCanvas(api, id, requireWriteToken({ id, entry }), nextToken).catch((error: unknown) => {
     if (error instanceof PrLensCliError) throw unfinishedRotation(error);
     throw error;
   });
@@ -143,29 +168,34 @@ const push = async (
   const ref = readString(values.canvas, "canvas");
   const known = ref === undefined ? findBySource(registry, source) : findCanvas(registry, ref);
 
-  const registered: Registered = await (async () => {
-    if (known !== undefined) return known;
+  const registered: Registered =
+    known ??
+    // Minted and recorded under one lock: a minted canvas whose token cannot
+    // be written down is a canvas lost, so the lock comes first, and a second
+    // push of the same file racing this one finds the entry instead of
+    // minting its own.
+    (await withRegistryLock(async () => {
+      const current = await readRegistry();
+      const meanwhile = ref === undefined ? findBySource(current, source) : undefined;
+      if (meanwhile !== undefined) return meanwhile;
 
-    const minted = await mintCanvas(api);
-    const entry = {
-      name: readString(values.name, "name") ?? document.title,
-      source: sourceKey(source),
-      writeToken: minted.writeToken,
-      rev: minted.rev,
-    };
-    // Recorded before the first push, so a push that fails can be tried again
-    // against the same canvas instead of minting another.
-    await updateRegistry((current) => {
+      const minted = await mintCanvas(api);
+      const entry: CanvasEntry = {
+        name: readString(values.name, "name") ?? document.title,
+        source: sourceKey(source),
+        writeToken: minted.writeToken,
+        rev: minted.rev,
+      };
       current.canvases[minted.id] = entry;
-    }, terminal);
-    return { id: minted.id, entry };
-  })();
+      await writeRegistry(current, terminal);
+      return { id: minted.id, entry };
+    }));
 
   const pending = registered.entry.nextWriteToken;
   const target =
     pending === undefined ? registered : (await settleRotation(api, registered, pending, terminal)).registered;
 
-  const pushed = await pushCanvas(api, target.id, target.entry.writeToken, target.entry.rev, document);
+  const pushed = await pushCanvas(api, target.id, requireWriteToken(target), target.entry.rev, document);
 
   await updateRegistry((current) => {
     current.canvases[target.id] = { ...(current.canvases[target.id] ?? target.entry), source: sourceKey(source), rev: pushed.rev };
@@ -193,10 +223,10 @@ const pull = async (
   const ref = readString(values.canvas, "canvas");
   const [positional] = positionals;
 
-  const { id, origin } =
+  const { id, origin, writeToken } =
     positional !== undefined
       ? readCanvasRef(positional)
-      : { id: (ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref)).id, origin: undefined };
+      : { ...(ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref)), origin: undefined, writeToken: undefined };
 
   // A pasted link says where it lives; --api still wins when both are given.
   const explicit = readString(values.api, "api");
@@ -206,14 +236,21 @@ const pull = async (
   const fetched = await fetchCanvas(api, id);
   await writeJsonFile(out, fetched.document);
 
-  if (registry.canvases[id] !== undefined) {
-    await updateRegistry((current) => {
-      const entry = current.canvases[id];
-      if (entry !== undefined) current.canvases[id] = { ...entry, rev: fetched.rev };
-    }, terminal);
-  }
+  // Every pull records the revision, and an edit link records its token: a
+  // checkout that lost canvas.json, or never had it, gets its pen back here.
+  await updateRegistry((current) => {
+    const entry = current.canvases[id];
+    current.canvases[id] = {
+      name: entry?.name ?? fetched.document.title,
+      source: entry?.source ?? sourceKey(out),
+      ...(entry?.nextWriteToken === undefined ? {} : { nextWriteToken: entry.nextWriteToken }),
+      ...(writeToken ?? entry?.writeToken) === undefined ? {} : { writeToken: writeToken ?? entry?.writeToken },
+      rev: fetched.rev,
+    };
+  }, terminal);
 
   terminal.out(`✓ ${out} — rev ${fetched.rev} of ${fetched.viewUrl}`);
+  if (writeToken !== undefined) terminal.out(`  the edit link's token is now in ${REGISTRY_PATH}`);
 };
 
 const rotate = async (

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -1,4 +1,5 @@
 import { assertNever } from "@coldtea/pr-lens-schema";
+import { resolve } from "node:path";
 import { parseOptions, readString } from "../args.js";
 import { fetchCanvas, mintCanvas, pushCanvas, rotateCanvas, verifyWriteToken } from "../canvas/api.js";
 import {
@@ -10,6 +11,7 @@ import {
   onlyCanvas,
   readRegistry,
   REGISTRY_PATH,
+  reservedRegistryPaths,
   sourceKey,
   updateRegistry,
   withRegistryLock,
@@ -98,6 +100,19 @@ const readCanvasRef = (value: string): CanvasRef => {
   return { id, origin: url.origin, writeToken };
 };
 
+/**
+ * An entry answers only for the app it was made against. Sending its token
+ * elsewhere gets a 404 that means nothing, and acting on that 404 would.
+ */
+const requireSameApi = (api: string, { id, entry }: Registered): void => {
+  if (entry.api === api) return;
+  throw new PrLensCliError(
+    "CANVAS_UNREGISTERED",
+    `${id} is registered against ${entry.api}, not ${api}`,
+    `pass --api ${entry.api}, or push the document without --canvas to mint a canvas here`,
+  );
+};
+
 /** The pen for a canvas, or the way to get one. */
 const requireWriteToken = ({ id, entry }: Registered): string => {
   if (entry.writeToken !== undefined) return entry.writeToken;
@@ -140,7 +155,7 @@ const settleRotation = async (
       // later would carry it out.
       await updateRegistry((registry) => {
         const current = registry.canvases[id];
-        if (current?.pending?.writeToken !== nextToken || current.pending.api !== api) return;
+        if (current === undefined || current.pending !== nextToken || current.api !== api) return;
         registry.canvases[id] = { ...current, pending: undefined };
       }, terminal);
       throw new PrLensCliError(
@@ -155,7 +170,7 @@ const settleRotation = async (
   // to a later rotation, which will close its own.
   await updateRegistry((registry) => {
     const current = registry.canvases[id];
-    if (current?.pending?.writeToken !== nextToken || current.pending.api !== api) return;
+    if (current === undefined || current.pending !== nextToken || current.api !== api) return;
     registry.canvases[id] = { ...current, writeToken: nextToken, pending: undefined };
   }, terminal);
 
@@ -163,17 +178,6 @@ const settleRotation = async (
     registered: { id, entry: { ...entry, writeToken: nextToken, pending: undefined } },
     editUrl: rotated.editUrl,
   };
-};
-
-/**
- * A rotation pending against another app is that app's to finish. Here it
- * is neither carried out nor dropped: this app's answers say nothing about
- * it. The stored token is used, and the reader is told.
- */
-const pendingElsewhere = (api: string, { id, entry }: Registered, terminal: Terminal): boolean => {
-  if (entry.pending === undefined || entry.pending.api === api) return false;
-  terminal.err(`  a rotation of ${id} is still pending against ${entry.pending.api}; run pr-lens canvas rotate --api ${entry.pending.api} to finish it`);
-  return true;
 };
 
 const push = async (
@@ -213,19 +217,35 @@ const push = async (
       const entry: CanvasEntry = {
         name: readString(values.name, "name") ?? document.title,
         source: sourceKey(source),
+        api,
         writeToken: minted.writeToken,
         rev: minted.rev,
       };
       current.canvases[minted.id] = entry;
-      await writeRegistry(current, terminal);
+      try {
+        await writeRegistry(current, terminal);
+      } catch (error) {
+        // The app has handed the token out, once. If it cannot be written
+        // down here, the terminal is the only place it can go.
+        if (!(error instanceof PrLensCliError)) throw error;
+        throw new PrLensCliError(
+          error.code,
+          `${error.message}; the canvas was minted and its token is not saved`,
+          [
+            `keep this edit link, it is the only copy: ${minted.editUrl}`,
+            "pull it once the registry can be written, and the token is recorded",
+            error.details ?? "",
+          ]
+            .filter((line) => line !== "")
+            .join("\n"),
+        );
+      }
       return { id: minted.id, entry };
     }));
 
+  requireSameApi(api, registered);
   const pending = registered.entry.pending;
-  const target =
-    pending === undefined || pendingElsewhere(api, registered, terminal)
-      ? registered
-      : (await settleRotation(api, registered, pending.writeToken, terminal)).registered;
+  const target = pending === undefined ? registered : (await settleRotation(api, registered, pending, terminal)).registered;
 
   const pushed = await pushCanvas(api, target.id, requireWriteToken(target), target.entry.rev, document);
 
@@ -264,6 +284,8 @@ const pull = async (
   const explicit = readString(values.api, "api");
   const api = explicit === undefined && origin !== undefined ? origin : readApi(explicit, env);
   const out = readString(values.out, "out") ?? DEFAULT_OUT;
+  if (reservedRegistryPaths().includes(resolve(out)))
+    throw usageError(`${out} is where the write tokens live; a document cannot be written there`);
 
   const fetched = await fetchCanvas(api, id);
   await writeJsonFile(out, fetched.document);
@@ -275,15 +297,20 @@ const pull = async (
   const seenToken = registry.canvases[id]?.writeToken;
   const proven = writeToken !== undefined && (await verifyWriteToken(api, id, writeToken));
 
-  type Recorded = "imported" | "kept" | "overtaken" | "refused";
+  type Recorded = "imported" | "kept" | "overtaken" | "refused" | "elsewhere";
   const outcome: { recorded: Recorded } = { recorded: "kept" };
 
   // Every pull records the revision, and a proven edit link records its
   // token: a checkout that lost canvas.json, or never had it, gets its pen
   // back here. A token that changes hands drops any rotation that was
   // pending for the old one; that rotation was the old holder's business.
+  // An entry made against another app is not this app's to change at all.
   await updateRegistry((current) => {
     const entry = current.canvases[id];
+    if (entry !== undefined && entry.api !== api) {
+      outcome.recorded = "elsewhere";
+      return;
+    }
     const untouched = entry?.writeToken === seenToken;
     const imports = proven && untouched && writeToken !== entry?.writeToken;
     outcome.recorded =
@@ -293,6 +320,7 @@ const pull = async (
     current.canvases[id] = {
       name: entry?.name ?? fetched.document.title,
       source: entry?.source ?? sourceKey(out),
+      api,
       ...(pending === undefined ? {} : { pending }),
       ...(kept === undefined ? {} : { writeToken: kept }),
       rev: fetched.rev,
@@ -309,6 +337,9 @@ const pull = async (
       return;
     case "overtaken":
       terminal.err(`  ${REGISTRY_PATH} changed while the edit link was being checked; its token was not recorded`);
+      return;
+    case "elsewhere":
+      terminal.err(`  ${id} is registered against another app in ${REGISTRY_PATH}; that entry was left as it is`);
       return;
     case "kept":
       return;
@@ -345,21 +376,15 @@ const rotate = async (
     // No pen, no rotation: a pending token written here would be carried
     // out by the next push once a pen arrives, retiring the very link that
     // brought it.
+    requireSameApi(api, { id, entry });
     requireWriteToken({ id, entry });
-    if (entry.pending !== undefined && entry.pending.api !== api)
-      throw new PrLensCliError(
-        "CANVAS_UNREGISTERED",
-        `a rotation of ${id} is still pending against ${entry.pending.api}`,
-        `finish it there first: pr-lens canvas rotate --api ${entry.pending.api}`,
-      );
-    const writeToken = entry.pending?.writeToken ?? mintWriteToken();
-    pending = { id, entry: { ...entry, pending: { writeToken, api } } };
+    pending = { id, entry: { ...entry, pending: entry.pending ?? mintWriteToken() } };
     current.canvases[id] = pending.entry;
   }, terminal);
   if (pending === undefined || pending.entry.pending === undefined)
     throw new PrLensCliError("CANVAS_UNREGISTERED", `${id} is no longer in ${REGISTRY_PATH}`);
 
-  const { editUrl } = await settleRotation(api, pending, pending.entry.pending.writeToken, terminal);
+  const { editUrl } = await settleRotation(api, pending, pending.entry.pending, terminal);
 
   const view = new URL(editUrl);
   view.hash = "";

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -13,7 +13,7 @@ import {
   type Registered,
 } from "../canvas/registry.js";
 import { readGraphDoc } from "../document.js";
-import { usageError } from "../errors.js";
+import { PrLensCliError, usageError } from "../errors.js";
 import { writeJsonFile } from "../io.js";
 import type { Terminal } from "../terminal.js";
 import { WORKSPACE_DIR } from "../workspace.js";
@@ -187,13 +187,24 @@ const rotate = async (
 
   const rotated = await rotateCanvas(api, id, entry.writeToken);
 
-  registry.canvases[id] = { ...entry, writeToken: rotated.writeToken };
-  await writeRegistry(registry, terminal);
-
+  // The old token is already retired, so the new one is the only way back
+  // in. Whatever happens to the registry, the link is shown.
   const view = new URL(rotated.editUrl);
   view.hash = "";
   terminal.out(`✓ new edit link for ${view.href}: ${rotated.editUrl}`);
   terminal.out("  the old edit link no longer works");
+
+  registry.canvases[id] = { ...entry, writeToken: rotated.writeToken };
+  try {
+    await writeRegistry(registry, terminal);
+  } catch (error) {
+    if (!(error instanceof PrLensCliError)) throw error;
+    throw new PrLensCliError(
+      error.code,
+      `${error.message}; the new edit link above is now the only copy of the token`,
+      error.details,
+    );
+  }
 };
 
 export const canvasCommand = async (

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -1,7 +1,13 @@
 import { assertNever } from "@coldtea/pr-lens-schema";
 import { resolve } from "node:path";
 import { parseOptions, readString } from "../args.js";
-import { fetchCanvas, mintCanvas, pushCanvas, rotateCanvas, verifyWriteToken } from "../canvas/api.js";
+import {
+  fetchCanvas,
+  mintCanvas,
+  pushCanvas,
+  rotateCanvas,
+  verifyWriteToken,
+} from "../canvas/api.js";
 import {
   ensureRegistryHome,
   findBySource,
@@ -58,7 +64,10 @@ in its fragment, so share the view link and keep the edit link to yourself.
 
   --api <url>                          the PR Lens app (default $${API_ENV}, else ${DEFAULT_API})`;
 
-const readApi = (value: unknown, env: Record<string, string | undefined>): string => {
+const readApi = (
+  value: unknown,
+  env: Record<string, string | undefined>,
+): string => {
   const api = readString(value, "api") ?? env[API_ENV] ?? DEFAULT_API;
   try {
     new URL(api);
@@ -68,24 +77,26 @@ const readApi = (value: unknown, env: Record<string, string | undefined>): strin
   return api.replace(/\/+$/, "");
 };
 
-type CanvasRef = { id: string; origin: string | undefined; writeToken: string | undefined };
+type CanvasRef = {
+  id: string;
+  origin: string | undefined;
+  writeToken: string | undefined;
+};
 
-/** A write token is 128 bits as base64url, the same shape as an id; anything else is not one. */
 const TOKEN_SHAPE = /^[A-Za-z0-9_-]{22}$/;
 
-/**
- * A bare id, or a link a page shows: {app}/c/{id}. An edit link carries the
- * write token in its fragment, and pulling one is how a checkout that never
- * pushed the canvas comes to hold its pen.
- */
+/** Pulling an edit link is how a checkout that never pushed a canvas gets its token. */
 const readCanvasRef = (value: string): CanvasRef => {
-  if (isCanvasId(value)) return { id: value, origin: undefined, writeToken: undefined };
+  if (isCanvasId(value))
+    return { id: value, origin: undefined, writeToken: undefined };
 
   const url = (() => {
     try {
       return new URL(value);
     } catch {
-      throw usageError(`expected a canvas id or a canvas URL, got ${JSON.stringify(value)}`);
+      throw usageError(
+        `expected a canvas id or a canvas URL, got ${JSON.stringify(value)}`,
+      );
     }
   })();
 
@@ -97,14 +108,14 @@ const readCanvasRef = (value: string): CanvasRef => {
   const fragment = new URLSearchParams(url.hash.replace(/^#/, ""));
   const writeToken = fragment.get("w") ?? undefined;
   if (writeToken !== undefined && !TOKEN_SHAPE.test(writeToken))
-    throw usageError(`${value} carries something after #w= that is not a write token`, "an edit link ends in #w= and 22 characters");
+    throw usageError(
+      `${value} carries something after #w= that is not a write token`,
+      "an edit link ends in #w= and 22 characters",
+    );
   return { id, origin: url.origin, writeToken };
 };
 
-/**
- * An entry answers only for the app it was made against. Sending its token
- * elsewhere gets a 404 that means nothing, and acting on that 404 would.
- */
+/** Another app's 404 means nothing about this entry, and acting on it would. */
 const requireSameApi = (api: string, { id, entry }: Registered): void => {
   if (entry.api === api) return;
   throw new PrLensCliError(
@@ -114,7 +125,6 @@ const requireSameApi = (api: string, { id, entry }: Registered): void => {
   );
 };
 
-/** The pen for a canvas, or the way to get one. */
 const requireWriteToken = ({ id, entry }: Registered): string => {
   if (entry.writeToken !== undefined) return entry.writeToken;
   throw new PrLensCliError(
@@ -124,59 +134,77 @@ const requireWriteToken = ({ id, entry }: Registered): string => {
   );
 };
 
-const countDiagrams = (count: number): string => `${count} ${count === 1 ? "diagram" : "diagrams"}`;
+const countDiagrams = (count: number): string =>
+  `${count} ${count === 1 ? "diagram" : "diagrams"}`;
 
 const unfinishedRotation = (error: PrLensCliError): PrLensCliError =>
   new PrLensCliError(
     error.code,
     `${error.message}; the rotation is not finished`,
-    [error.details, "run pr-lens canvas rotate again to finish it: the new token is kept until the app confirms it"]
+    [
+      error.details,
+      "run pr-lens canvas rotate again to finish it: the new token is kept until the app confirms it",
+    ]
       .filter((line) => line !== undefined && line !== "")
       .join("\n"),
   );
 
-/**
- * Finishes a rotation whose answer never arrived. The app takes the same
- * pair again and says "rotated" once the new token is the one on record.
- */
+/** Asking again with the same pair is safe: the app answers "rotated" once the token is on record. */
 const settleRotation = async (
   api: string,
   { id, entry }: Registered,
   nextToken: string,
   terminal: Terminal,
 ): Promise<{ registered: Registered; editUrl: string }> => {
-  const rotated = await rotateCanvas(api, id, requireWriteToken({ id, entry }), nextToken).catch(
-    async (error: unknown) => {
-      if (!(error instanceof PrLensCliError)) throw error;
-      if (error.code !== "CANVAS_UNKNOWN") throw unfinishedRotation(error);
+  const rotated = await rotateCanvas(
+    api,
+    id,
+    requireWriteToken({ id, entry }),
+    nextToken,
+  ).catch(async (error: unknown) => {
+    if (!(error instanceof PrLensCliError)) throw error;
+    if (error.code !== "CANVAS_UNKNOWN") throw unfinishedRotation(error);
 
-      // Conclusive: the app would have said "rotated" if the pending token
-      // were the one on record, so neither it nor the stored token opens
-      // the canvas. The transition is abandoned here, or a token imported
-      // later would carry it out.
-      await updateRegistry((registry) => {
-        const current = registry.canvases[id];
-        if (current === undefined || current.pending !== nextToken || current.api !== api) return;
-        registry.canvases[id] = { ...current, pending: undefined };
-      }, terminal);
-      throw new PrLensCliError(
-        error.code,
-        `${error.message}; the rotation that was pending has been dropped`,
-        error.details,
-      );
-    },
-  );
+    // Conclusive, since a current pending token would have been answered
+    // "rotated". Dropped here, or a token imported later would carry it out.
+    await updateRegistry((registry) => {
+      const current = registry.canvases[id];
+      if (
+        current === undefined ||
+        current.pending !== nextToken ||
+        current.api !== api
+      )
+        return;
+      registry.canvases[id] = { ...current, pending: undefined };
+    }, terminal);
+    throw new PrLensCliError(
+      error.code,
+      `${error.message}; the rotation that was pending has been dropped`,
+      error.details,
+    );
+  });
 
-  // Only this transition is closed. A different token pending by now belongs
-  // to a later rotation, which will close its own.
+  // A different token pending by now belongs to a later rotation.
   await updateRegistry((registry) => {
     const current = registry.canvases[id];
-    if (current === undefined || current.pending !== nextToken || current.api !== api) return;
-    registry.canvases[id] = { ...current, writeToken: nextToken, pending: undefined };
+    if (
+      current === undefined ||
+      current.pending !== nextToken ||
+      current.api !== api
+    )
+      return;
+    registry.canvases[id] = {
+      ...current,
+      writeToken: nextToken,
+      pending: undefined,
+    };
   }, terminal);
 
   return {
-    registered: { id, entry: { ...entry, writeToken: nextToken, pending: undefined } },
+    registered: {
+      id,
+      entry: { ...entry, writeToken: nextToken, pending: undefined },
+    },
     editUrl: rotated.editUrl,
   };
 };
@@ -186,57 +214,71 @@ type Recorded = "imported" | "kept" | "overtaken" | "refused" | "elsewhere";
 type PullRecord = {
   api: string;
   id: string;
-  /** What the app showed, or nothing for a canvas minted and never pushed to. */
+  /** Undefined for a canvas minted and never pushed to. */
   fetched: { rev: number; title: string } | undefined;
   out: string;
   writeToken: string | undefined;
-  /** The stored token when the proof was made; a different one now means the proof is stale. */
+  /** The stored token when the proof was made; if it changed since, the proof is stale. */
   seenToken: string | undefined;
   proven: boolean;
 };
 
 /**
- * What a pull leaves in the registry, decided under the lock. Every pull
- * records the revision it saw, and a proven edit link records its token: a
- * checkout that lost canvas.json, or never had it, gets its pen back here.
- * A token that changes hands drops any rotation that was pending for the
- * old one; that rotation was the old holder's business. The same token
- * again leaves a pending rotation where it is. An entry made against
- * another app is not this app's to change at all.
+ * Decided under the lock. A token that changes hands drops a pending
+ * rotation, which was the old holder's business; the same token keeps it.
  */
 const recordPull = (current: CanvasRegistry, pull: PullRecord): Recorded => {
   const entry = current.canvases[pull.id];
   if (entry !== undefined && entry.api !== pull.api) return "elsewhere";
 
   const untouched = entry?.writeToken === pull.seenToken;
-  const imports = pull.proven && untouched && pull.writeToken !== entry?.writeToken;
+  const imports =
+    pull.proven && untouched && pull.writeToken !== entry?.writeToken;
   const kept = imports ? pull.writeToken : entry?.writeToken;
   const pending = imports ? undefined : entry?.pending;
   current.canvases[pull.id] = {
     name: entry?.name ?? pull.fetched?.title ?? pull.id,
-    source: entry?.source ?? (pull.fetched === undefined ? DEFAULT_SOURCE : sourceKey(pull.out)),
+    source:
+      entry?.source ??
+      (pull.fetched === undefined ? DEFAULT_SOURCE : sourceKey(pull.out)),
     api: pull.api,
     ...(pending === undefined ? {} : { pending }),
     ...(kept === undefined ? {} : { writeToken: kept }),
     rev: pull.fetched?.rev ?? entry?.rev ?? 0,
   };
 
-  return imports ? "imported" : pull.proven && !untouched ? "overtaken" : pull.writeToken !== undefined && !pull.proven ? "refused" : "kept";
+  return imports
+    ? "imported"
+    : pull.proven && !untouched
+      ? "overtaken"
+      : pull.writeToken !== undefined && !pull.proven
+        ? "refused"
+        : "kept";
 };
 
-const tellRecorded = (recorded: Recorded, id: string, terminal: Terminal): void => {
+const tellRecorded = (
+  recorded: Recorded,
+  id: string,
+  terminal: Terminal,
+): void => {
   switch (recorded) {
     case "imported":
       terminal.out(`  the edit link's token is now in ${REGISTRY_PATH}`);
       return;
     case "refused":
-      terminal.err(`  the edit link's token no longer opens ${id}; nothing was recorded for it`);
+      terminal.err(
+        `  the edit link's token no longer opens ${id}; nothing was recorded for it`,
+      );
       return;
     case "overtaken":
-      terminal.err(`  ${REGISTRY_PATH} changed while the edit link was being checked; its token was not recorded`);
+      terminal.err(
+        `  ${REGISTRY_PATH} changed while the edit link was being checked; its token was not recorded`,
+      );
       return;
     case "elsewhere":
-      terminal.err(`  ${id} is registered against another app in ${REGISTRY_PATH}; that entry was left as it is`);
+      terminal.err(
+        `  ${id} is registered against another app in ${REGISTRY_PATH}; that entry was left as it is`,
+      );
       return;
     case "kept":
       return;
@@ -256,7 +298,9 @@ const push = async (
     api: { type: "string" },
   });
   if (positionals.length > 1)
-    throw usageError(`push takes one graph document, got ${positionals.length}`);
+    throw usageError(
+      `push takes one graph document, got ${positionals.length}`,
+    );
 
   const source = positionals[0] ?? DEFAULT_SOURCE;
   const document = await readGraphDoc(source);
@@ -265,17 +309,19 @@ const push = async (
   const registry = await readRegistry();
 
   const ref = readString(values.canvas, "canvas");
-  const known = ref === undefined ? findBySource(registry, source) : findCanvas(registry, ref);
+  const known =
+    ref === undefined
+      ? findBySource(registry, source)
+      : findCanvas(registry, ref);
 
   const registered: Registered =
     known ??
-    // Minted and recorded under one lock: a minted canvas whose token cannot
-    // be written down is a canvas lost, so the lock comes first, and a second
-    // push of the same file racing this one finds the entry instead of
-    // minting its own.
+    // Under the lock, so a racing push of the same file finds this entry
+    // instead of minting its own.
     (await withRegistryLock(async () => {
       const current = await readRegistry();
-      const meanwhile = ref === undefined ? findBySource(current, source) : undefined;
+      const meanwhile =
+        ref === undefined ? findBySource(current, source) : undefined;
       if (meanwhile !== undefined) return meanwhile;
 
       const minted = await mintCanvas(api);
@@ -290,8 +336,7 @@ const push = async (
       try {
         await writeRegistry(current, terminal);
       } catch (error) {
-        // The app has handed the token out, once. If it cannot be written
-        // down here, the terminal is the only place it can go.
+        // The app hands the token out once; the terminal is the only place left for it.
         if (!(error instanceof PrLensCliError)) throw error;
         throw new PrLensCliError(
           error.code,
@@ -310,15 +355,30 @@ const push = async (
 
   requireSameApi(api, registered);
   const pending = registered.entry.pending;
-  const target = pending === undefined ? registered : (await settleRotation(api, registered, pending, terminal)).registered;
+  const target =
+    pending === undefined
+      ? registered
+      : (await settleRotation(api, registered, pending, terminal)).registered;
 
-  const pushed = await pushCanvas(api, target.id, requireWriteToken(target), target.entry.rev, document);
+  const pushed = await pushCanvas(
+    api,
+    target.id,
+    requireWriteToken(target),
+    target.entry.rev,
+    document,
+  );
 
   await updateRegistry((current) => {
-    current.canvases[target.id] = { ...(current.canvases[target.id] ?? target.entry), source: sourceKey(source), rev: pushed.rev };
+    current.canvases[target.id] = {
+      ...(current.canvases[target.id] ?? target.entry),
+      source: sourceKey(source),
+      rev: pushed.rev,
+    };
   }, terminal);
 
-  terminal.out(`✓ ${pushed.viewUrl} — rev ${pushed.rev} · ${countDiagrams(pushed.tiles.length)}`);
+  terminal.out(
+    `✓ ${pushed.viewUrl} — rev ${pushed.rev} · ${countDiagrams(pushed.tiles.length)}`,
+  );
   terminal.out(`  edit link, keep it to yourself: ${pushed.editUrl}`);
   terminal.out(`  README embed: ${pushed.embedUrl}`);
 };
@@ -334,7 +394,9 @@ const pull = async (
     api: { type: "string" },
   });
   if (positionals.length > 1)
-    throw usageError(`pull takes one canvas url or id, got ${positionals.length}`);
+    throw usageError(
+      `pull takes one canvas url or id, got ${positionals.length}`,
+    );
 
   const registry = await readRegistry();
   const ref = readString(values.canvas, "canvas");
@@ -343,28 +405,40 @@ const pull = async (
   const { id, origin, writeToken } =
     positional !== undefined
       ? readCanvasRef(positional)
-      : { ...(ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref)), origin: undefined, writeToken: undefined };
+      : {
+          ...(ref === undefined
+            ? onlyCanvas(registry)
+            : findCanvas(registry, ref)),
+          origin: undefined,
+          writeToken: undefined,
+        };
 
-  // A pasted link says where it lives; --api still wins when both are given.
+  // A pasted link says where it lives; --api still wins.
   const explicit = readString(values.api, "api");
-  const api = explicit === undefined && origin !== undefined ? origin : readApi(explicit, env);
+  const api =
+    explicit === undefined && origin !== undefined
+      ? origin
+      : readApi(explicit, env);
   const out = readString(values.out, "out") ?? DEFAULT_OUT;
   if (await isReservedRegistryTarget(out))
-    throw usageError(`${out} is where the write tokens live; a document cannot be written there`);
+    throw usageError(
+      `${out} is where the write tokens live; a document cannot be written there`,
+    );
 
-  // An edit link's token is proven before it is written down: an old
-  // bookmark from before a rotation must not replace the token that works.
-  // The proof is about the entry as it was read; if another command changes
-  // the entry in the meantime, the proof is stale and is not acted on. It
-  // comes before the fetch because a canvas nobody has pushed to yet has
-  // nothing to fetch, and its edit link is still worth registering.
+  // Proven before the fetch: an old bookmark must not replace the token
+  // that works, and an unpushed canvas has nothing to fetch yet.
   const seenToken = registry.canvases[id]?.writeToken;
-  const proven = writeToken !== undefined && (await verifyWriteToken(api, id, writeToken));
+  const proven =
+    writeToken !== undefined && (await verifyWriteToken(api, id, writeToken));
 
   const fetched = await fetchCanvas(api, id).catch((error: unknown) => {
-    // Minted and never pushed: the app shows nothing yet, but a proven pen
-    // is real, and recording it is the whole point of pulling an edit link.
-    if (error instanceof PrLensCliError && error.code === "CANVAS_UNKNOWN" && proven) return undefined;
+    // Minted and never pushed: nothing to show, but a proven token is worth recording.
+    if (
+      error instanceof PrLensCliError &&
+      error.code === "CANVAS_UNKNOWN" &&
+      proven
+    )
+      return undefined;
     throw error;
   });
   if (fetched !== undefined) await writeJsonFile(out, fetched.document);
@@ -374,7 +448,10 @@ const pull = async (
     outcome.recorded = recordPull(current, {
       api,
       id,
-      fetched: fetched === undefined ? undefined : { rev: fetched.rev, title: fetched.document.title },
+      fetched:
+        fetched === undefined
+          ? undefined
+          : { rev: fetched.rev, title: fetched.document.title },
       out,
       writeToken,
       seenToken,
@@ -400,33 +477,45 @@ const rotate = async (
     api: { type: "string" },
   });
   if (positionals.length > 0)
-    throw usageError(`rotate takes no positional arguments, got ${positionals.join(" ")}`);
+    throw usageError(
+      `rotate takes no positional arguments, got ${positionals.join(" ")}`,
+    );
 
   const api = readApi(values.api, env);
   await ensureRegistryHome(terminal);
   const registry = await readRegistry();
   const ref = readString(values.canvas, "canvas");
-  const { id } = ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref);
+  const { id } =
+    ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref);
 
-  // The new token is written down before the app hears of it, so nothing
-  // that happens on the way back can leave the canvas without a holder. It
-  // is chosen under the lock: two rotations at once finish the same one.
+  // Written down before the app hears of it, so a lost answer cannot lose
+  // it; chosen under the lock, so two rotations at once finish the same one.
   let pending: Registered | undefined;
   await updateRegistry((current) => {
     const entry = current.canvases[id];
     if (entry === undefined) return;
-    // No pen, no rotation: a pending token written here would be carried
-    // out by the next push once a pen arrives, retiring the very link that
-    // brought it.
+    // Without a token, a pending rotation would be carried out by whatever
+    // token arrives next, retiring the very link that brought it.
     requireSameApi(api, { id, entry });
     requireWriteToken({ id, entry });
-    pending = { id, entry: { ...entry, pending: entry.pending ?? mintWriteToken() } };
+    pending = {
+      id,
+      entry: { ...entry, pending: entry.pending ?? mintWriteToken() },
+    };
     current.canvases[id] = pending.entry;
   }, terminal);
   if (pending === undefined || pending.entry.pending === undefined)
-    throw new PrLensCliError("CANVAS_UNREGISTERED", `${id} is no longer in ${REGISTRY_PATH}`);
+    throw new PrLensCliError(
+      "CANVAS_UNREGISTERED",
+      `${id} is no longer in ${REGISTRY_PATH}`,
+    );
 
-  const { editUrl } = await settleRotation(api, pending, pending.entry.pending, terminal);
+  const { editUrl } = await settleRotation(
+    api,
+    pending,
+    pending.entry.pending,
+    terminal,
+  );
 
   const view = new URL(editUrl);
   view.hash = "";
@@ -440,8 +529,10 @@ export const canvasCommand = async (
   env: Record<string, string | undefined>,
 ): Promise<void> => {
   const [name, ...rest] = args;
-  if (name === undefined) throw usageError("canvas needs a subcommand: push, pull or rotate");
-  if (!isSubcommand(name)) throw usageError(`unknown canvas subcommand ${JSON.stringify(name)}`);
+  if (name === undefined)
+    throw usageError("canvas needs a subcommand: push, pull or rotate");
+  if (!isSubcommand(name))
+    throw usageError(`unknown canvas subcommand ${JSON.stringify(name)}`);
 
   switch (name) {
     case "push":

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -17,6 +17,7 @@ import {
   withRegistryLock,
   writeRegistry,
   type CanvasEntry,
+  type CanvasRegistry,
   type Registered,
 } from "../canvas/registry.js";
 import { readGraphDoc } from "../document.js";
@@ -180,25 +181,69 @@ const settleRotation = async (
   };
 };
 
-/** An edit link for a canvas nobody has pushed to: registered at rev 0, the way a mint is. */
-const registerUnpushed = (
-  api: string,
-  id: string,
-  writeToken: string,
-  seenToken: string | undefined,
-  terminal: Terminal,
-): Promise<unknown> =>
-  updateRegistry((current) => {
-    const entry = current.canvases[id];
-    if (entry !== undefined && (entry.api !== api || entry.writeToken !== seenToken)) return;
-    current.canvases[id] = {
-      name: entry?.name ?? id,
-      source: entry?.source ?? DEFAULT_SOURCE,
-      api,
-      writeToken,
-      rev: entry?.rev ?? 0,
-    };
-  }, terminal);
+type Recorded = "imported" | "kept" | "overtaken" | "refused" | "elsewhere";
+
+type PullRecord = {
+  api: string;
+  id: string;
+  /** What the app showed, or nothing for a canvas minted and never pushed to. */
+  fetched: { rev: number; title: string } | undefined;
+  out: string;
+  writeToken: string | undefined;
+  /** The stored token when the proof was made; a different one now means the proof is stale. */
+  seenToken: string | undefined;
+  proven: boolean;
+};
+
+/**
+ * What a pull leaves in the registry, decided under the lock. Every pull
+ * records the revision it saw, and a proven edit link records its token: a
+ * checkout that lost canvas.json, or never had it, gets its pen back here.
+ * A token that changes hands drops any rotation that was pending for the
+ * old one; that rotation was the old holder's business. The same token
+ * again leaves a pending rotation where it is. An entry made against
+ * another app is not this app's to change at all.
+ */
+const recordPull = (current: CanvasRegistry, pull: PullRecord): Recorded => {
+  const entry = current.canvases[pull.id];
+  if (entry !== undefined && entry.api !== pull.api) return "elsewhere";
+
+  const untouched = entry?.writeToken === pull.seenToken;
+  const imports = pull.proven && untouched && pull.writeToken !== entry?.writeToken;
+  const kept = imports ? pull.writeToken : entry?.writeToken;
+  const pending = imports ? undefined : entry?.pending;
+  current.canvases[pull.id] = {
+    name: entry?.name ?? pull.fetched?.title ?? pull.id,
+    source: entry?.source ?? (pull.fetched === undefined ? DEFAULT_SOURCE : sourceKey(pull.out)),
+    api: pull.api,
+    ...(pending === undefined ? {} : { pending }),
+    ...(kept === undefined ? {} : { writeToken: kept }),
+    rev: pull.fetched?.rev ?? entry?.rev ?? 0,
+  };
+
+  return imports ? "imported" : pull.proven && !untouched ? "overtaken" : pull.writeToken !== undefined && !pull.proven ? "refused" : "kept";
+};
+
+const tellRecorded = (recorded: Recorded, id: string, terminal: Terminal): void => {
+  switch (recorded) {
+    case "imported":
+      terminal.out(`  the edit link's token is now in ${REGISTRY_PATH}`);
+      return;
+    case "refused":
+      terminal.err(`  the edit link's token no longer opens ${id}; nothing was recorded for it`);
+      return;
+    case "overtaken":
+      terminal.err(`  ${REGISTRY_PATH} changed while the edit link was being checked; its token was not recorded`);
+      return;
+    case "elsewhere":
+      terminal.err(`  ${id} is registered against another app in ${REGISTRY_PATH}; that entry was left as it is`);
+      return;
+    case "kept":
+      return;
+    default:
+      return assertNever(recorded, "Unhandled record outcome");
+  }
+};
 
 const push = async (
   args: readonly string[],
@@ -316,68 +361,33 @@ const pull = async (
   const seenToken = registry.canvases[id]?.writeToken;
   const proven = writeToken !== undefined && (await verifyWriteToken(api, id, writeToken));
 
-  const fetched = await fetchCanvas(api, id).catch(async (error: unknown) => {
-    if (!(error instanceof PrLensCliError) || error.code !== "CANVAS_UNKNOWN" || !proven) throw error;
-    // Minted and never pushed: the app shows nothing yet, but the pen is
-    // real, and recording it is the whole point of pulling an edit link.
-    await registerUnpushed(api, id, writeToken, seenToken, terminal);
-    return undefined;
+  const fetched = await fetchCanvas(api, id).catch((error: unknown) => {
+    // Minted and never pushed: the app shows nothing yet, but a proven pen
+    // is real, and recording it is the whole point of pulling an edit link.
+    if (error instanceof PrLensCliError && error.code === "CANVAS_UNKNOWN" && proven) return undefined;
+    throw error;
   });
-  if (fetched === undefined) {
-    terminal.out(`✓ ${id} has nothing pushed to it yet; its token is now in ${REGISTRY_PATH}`);
-    return;
-  }
-  await writeJsonFile(out, fetched.document);
+  if (fetched !== undefined) await writeJsonFile(out, fetched.document);
 
-  type Recorded = "imported" | "kept" | "overtaken" | "refused" | "elsewhere";
   const outcome: { recorded: Recorded } = { recorded: "kept" };
-
-  // Every pull records the revision, and a proven edit link records its
-  // token: a checkout that lost canvas.json, or never had it, gets its pen
-  // back here. A token that changes hands drops any rotation that was
-  // pending for the old one; that rotation was the old holder's business.
-  // An entry made against another app is not this app's to change at all.
   await updateRegistry((current) => {
-    const entry = current.canvases[id];
-    if (entry !== undefined && entry.api !== api) {
-      outcome.recorded = "elsewhere";
-      return;
-    }
-    const untouched = entry?.writeToken === seenToken;
-    const imports = proven && untouched && writeToken !== entry?.writeToken;
-    outcome.recorded =
-      imports ? "imported" : proven && !untouched ? "overtaken" : writeToken !== undefined && !proven ? "refused" : "kept";
-    const kept = imports ? writeToken : entry?.writeToken;
-    const pending = imports ? undefined : entry?.pending;
-    current.canvases[id] = {
-      name: entry?.name ?? fetched.document.title,
-      source: entry?.source ?? sourceKey(out),
+    outcome.recorded = recordPull(current, {
       api,
-      ...(pending === undefined ? {} : { pending }),
-      ...(kept === undefined ? {} : { writeToken: kept }),
-      rev: fetched.rev,
-    };
+      id,
+      fetched: fetched === undefined ? undefined : { rev: fetched.rev, title: fetched.document.title },
+      out,
+      writeToken,
+      seenToken,
+      proven,
+    });
   }, terminal);
 
-  terminal.out(`✓ ${out} — rev ${fetched.rev} of ${fetched.viewUrl}`);
-  switch (outcome.recorded) {
-    case "imported":
-      terminal.out(`  the edit link's token is now in ${REGISTRY_PATH}`);
-      return;
-    case "refused":
-      terminal.err(`  the edit link's token no longer opens ${id}; nothing was recorded for it`);
-      return;
-    case "overtaken":
-      terminal.err(`  ${REGISTRY_PATH} changed while the edit link was being checked; its token was not recorded`);
-      return;
-    case "elsewhere":
-      terminal.err(`  ${id} is registered against another app in ${REGISTRY_PATH}; that entry was left as it is`);
-      return;
-    case "kept":
-      return;
-    default:
-      return assertNever(outcome.recorded, "Unhandled record outcome");
-  }
+  terminal.out(
+    fetched === undefined
+      ? `✓ ${id} has nothing pushed to it yet`
+      : `✓ ${out} — rev ${fetched.rev} of ${fetched.viewUrl}`,
+  );
+  tellRecorded(outcome.recorded, id, terminal);
 };
 
 const rotate = async (

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -2,14 +2,16 @@ import { assertNever } from "@coldtea/pr-lens-schema";
 import { parseOptions, readString } from "../args.js";
 import { fetchCanvas, mintCanvas, pushCanvas, rotateCanvas } from "../canvas/api.js";
 import {
+  ensureRegistryHome,
   findBySource,
   findCanvas,
   isCanvasId,
+  mintWriteToken,
   onlyCanvas,
   readRegistry,
   REGISTRY_PATH,
   sourceKey,
-  writeRegistry,
+  updateRegistry,
   type Registered,
 } from "../canvas/registry.js";
 import { readGraphDoc } from "../document.js";
@@ -81,6 +83,39 @@ const readCanvasRef = (value: string): { id: string; origin: string | undefined 
 
 const countDiagrams = (count: number): string => `${count} ${count === 1 ? "diagram" : "diagrams"}`;
 
+const unfinishedRotation = (error: PrLensCliError): PrLensCliError =>
+  new PrLensCliError(
+    error.code,
+    `${error.message}; the rotation is not finished`,
+    [error.details, "run pr-lens canvas rotate again to finish it: the new token is kept until the app confirms it"]
+      .filter((line) => line !== undefined && line !== "")
+      .join("\n"),
+  );
+
+/**
+ * Finishes a rotation whose answer never arrived. The app takes the same
+ * pair again and says "rotated" once the new token is the one on record.
+ */
+const settleRotation = async (
+  api: string,
+  { id, entry }: Registered,
+  nextToken: string,
+  terminal: Terminal,
+): Promise<Registered> => {
+  try {
+    await rotateCanvas(api, id, entry.writeToken, nextToken);
+  } catch (error) {
+    if (error instanceof PrLensCliError) throw unfinishedRotation(error);
+    throw error;
+  }
+
+  const settled = { ...entry, writeToken: nextToken, nextWriteToken: undefined };
+  await updateRegistry((registry) => {
+    registry.canvases[id] = { ...(registry.canvases[id] ?? entry), writeToken: nextToken, nextWriteToken: undefined };
+  }, terminal);
+  return { id, entry: settled };
+};
+
 const push = async (
   args: readonly string[],
   terminal: Terminal,
@@ -97,12 +132,13 @@ const push = async (
   const source = positionals[0] ?? DEFAULT_SOURCE;
   const document = await readGraphDoc(source);
   const api = readApi(values.api, env);
+  await ensureRegistryHome(terminal);
   const registry = await readRegistry();
 
   const ref = readString(values.canvas, "canvas");
   const known = ref === undefined ? findBySource(registry, source) : findCanvas(registry, ref);
 
-  const target: Registered = await (async () => {
+  const registered: Registered = await (async () => {
     if (known !== undefined) return known;
 
     const minted = await mintCanvas(api);
@@ -114,15 +150,20 @@ const push = async (
     };
     // Recorded before the first push, so a push that fails can be tried again
     // against the same canvas instead of minting another.
-    registry.canvases[minted.id] = entry;
-    await writeRegistry(registry, terminal);
+    await updateRegistry((current) => {
+      current.canvases[minted.id] = entry;
+    }, terminal);
     return { id: minted.id, entry };
   })();
 
+  const pending = registered.entry.nextWriteToken;
+  const target = pending === undefined ? registered : await settleRotation(api, registered, pending, terminal);
+
   const pushed = await pushCanvas(api, target.id, target.entry.writeToken, target.entry.rev, document);
 
-  registry.canvases[target.id] = { ...target.entry, source: sourceKey(source), rev: pushed.rev };
-  await writeRegistry(registry, terminal);
+  await updateRegistry((current) => {
+    current.canvases[target.id] = { ...(current.canvases[target.id] ?? target.entry), source: sourceKey(source), rev: pushed.rev };
+  }, terminal);
 
   terminal.out(`✓ ${pushed.viewUrl} — rev ${pushed.rev} · ${countDiagrams(pushed.tiles.length)}`);
   terminal.out(`  edit link, keep it to yourself: ${pushed.editUrl}`);
@@ -159,10 +200,11 @@ const pull = async (
   const fetched = await fetchCanvas(api, id);
   await writeJsonFile(out, fetched.document);
 
-  const entry = registry.canvases[id];
-  if (entry !== undefined) {
-    registry.canvases[id] = { ...entry, rev: fetched.rev };
-    await writeRegistry(registry, terminal);
+  if (registry.canvases[id] !== undefined) {
+    await updateRegistry((current) => {
+      const entry = current.canvases[id];
+      if (entry !== undefined) current.canvases[id] = { ...entry, rev: fetched.rev };
+    }, terminal);
   }
 
   terminal.out(`✓ ${out} — rev ${fetched.rev} of ${fetched.viewUrl}`);
@@ -181,30 +223,25 @@ const rotate = async (
     throw usageError(`rotate takes no positional arguments, got ${positionals.join(" ")}`);
 
   const api = readApi(values.api, env);
+  await ensureRegistryHome(terminal);
   const registry = await readRegistry();
   const ref = readString(values.canvas, "canvas");
-  const { id, entry } = ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref);
+  const registered = ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref);
+  const { id, entry } = registered;
 
-  const rotated = await rotateCanvas(api, id, entry.writeToken);
+  // The new token is written down before the app hears of it, so nothing
+  // that happens on the way back can leave the canvas without a holder.
+  const nextToken = entry.nextWriteToken ?? mintWriteToken();
+  await updateRegistry((current) => {
+    current.canvases[id] = { ...(current.canvases[id] ?? entry), nextWriteToken: nextToken };
+  }, terminal);
 
-  // The old token is already retired, so the new one is the only way back
-  // in. Whatever happens to the registry, the link is shown.
-  const view = new URL(rotated.editUrl);
-  view.hash = "";
-  terminal.out(`✓ new edit link for ${view.href}: ${rotated.editUrl}`);
+  const settled = await settleRotation(api, registered, nextToken, terminal);
+
+  const view = new URL(api);
+  view.pathname = `/c/${id}`;
+  terminal.out(`✓ new edit link for ${view.href}: ${view.href}#w=${settled.entry.writeToken}`);
   terminal.out("  the old edit link no longer works");
-
-  registry.canvases[id] = { ...entry, writeToken: rotated.writeToken };
-  try {
-    await writeRegistry(registry, terminal);
-  } catch (error) {
-    if (!(error instanceof PrLensCliError)) throw error;
-    throw new PrLensCliError(
-      error.code,
-      `${error.message}; the new edit link above is now the only copy of the token`,
-      error.details,
-    );
-  }
 };
 
 export const canvasCommand = async (

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -101,19 +101,24 @@ const settleRotation = async (
   { id, entry }: Registered,
   nextToken: string,
   terminal: Terminal,
-): Promise<Registered> => {
-  try {
-    await rotateCanvas(api, id, entry.writeToken, nextToken);
-  } catch (error) {
+): Promise<{ registered: Registered; editUrl: string }> => {
+  const rotated = await rotateCanvas(api, id, entry.writeToken, nextToken).catch((error: unknown) => {
     if (error instanceof PrLensCliError) throw unfinishedRotation(error);
     throw error;
-  }
+  });
 
-  const settled = { ...entry, writeToken: nextToken, nextWriteToken: undefined };
+  // Only this transition is closed. A different token pending by now belongs
+  // to a later rotation, which will close its own.
   await updateRegistry((registry) => {
-    registry.canvases[id] = { ...(registry.canvases[id] ?? entry), writeToken: nextToken, nextWriteToken: undefined };
+    const current = registry.canvases[id];
+    if (current === undefined || current.nextWriteToken !== nextToken) return;
+    registry.canvases[id] = { ...current, writeToken: nextToken, nextWriteToken: undefined };
   }, terminal);
-  return { id, entry: settled };
+
+  return {
+    registered: { id, entry: { ...entry, writeToken: nextToken, nextWriteToken: undefined } },
+    editUrl: rotated.editUrl,
+  };
 };
 
 const push = async (
@@ -157,7 +162,8 @@ const push = async (
   })();
 
   const pending = registered.entry.nextWriteToken;
-  const target = pending === undefined ? registered : await settleRotation(api, registered, pending, terminal);
+  const target =
+    pending === undefined ? registered : (await settleRotation(api, registered, pending, terminal)).registered;
 
   const pushed = await pushCanvas(api, target.id, target.entry.writeToken, target.entry.rev, document);
 
@@ -226,21 +232,27 @@ const rotate = async (
   await ensureRegistryHome(terminal);
   const registry = await readRegistry();
   const ref = readString(values.canvas, "canvas");
-  const registered = ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref);
-  const { id, entry } = registered;
+  const { id } = ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref);
 
   // The new token is written down before the app hears of it, so nothing
-  // that happens on the way back can leave the canvas without a holder.
-  const nextToken = entry.nextWriteToken ?? mintWriteToken();
+  // that happens on the way back can leave the canvas without a holder. It
+  // is chosen under the lock: two rotations at once finish the same one.
+  let pending: Registered | undefined;
   await updateRegistry((current) => {
-    current.canvases[id] = { ...(current.canvases[id] ?? entry), nextWriteToken: nextToken };
+    const entry = current.canvases[id];
+    if (entry === undefined) return;
+    const nextWriteToken = entry.nextWriteToken ?? mintWriteToken();
+    pending = { id, entry: { ...entry, nextWriteToken } };
+    current.canvases[id] = pending.entry;
   }, terminal);
+  if (pending === undefined || pending.entry.nextWriteToken === undefined)
+    throw new PrLensCliError("CANVAS_UNREGISTERED", `${id} is no longer in ${REGISTRY_PATH}`);
 
-  const settled = await settleRotation(api, registered, nextToken, terminal);
+  const { editUrl } = await settleRotation(api, pending, pending.entry.nextWriteToken, terminal);
 
-  const view = new URL(api);
-  view.pathname = `/c/${id}`;
-  terminal.out(`✓ new edit link for ${view.href}: ${view.href}#w=${settled.entry.writeToken}`);
+  const view = new URL(editUrl);
+  view.hash = "";
+  terminal.out(`✓ new edit link for ${view.href}: ${editUrl}`);
   terminal.out("  the old edit link no longer works");
 };
 

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -1,0 +1,218 @@
+import { assertNever } from "@coldtea/pr-lens-schema";
+import { parseOptions, readString } from "../args.js";
+import { fetchCanvas, mintCanvas, pushCanvas, rotateCanvas } from "../canvas/api.js";
+import {
+  findBySource,
+  findCanvas,
+  isCanvasId,
+  onlyCanvas,
+  readRegistry,
+  REGISTRY_PATH,
+  sourceKey,
+  writeRegistry,
+  type Registered,
+} from "../canvas/registry.js";
+import { readGraphDoc } from "../document.js";
+import { usageError } from "../errors.js";
+import { writeJsonFile } from "../io.js";
+import type { Terminal } from "../terminal.js";
+import { WORKSPACE_DIR } from "../workspace.js";
+
+const DEFAULT_API = "https://prlens.dev";
+const API_ENV = "PR_LENS_API_URL";
+const DEFAULT_SOURCE = `${WORKSPACE_DIR}/drawn.graph.json`;
+const DEFAULT_OUT = `${WORKSPACE_DIR}/graph.json`;
+
+const SUBCOMMANDS = ["push", "pull", "rotate"] as const;
+type Subcommand = (typeof SUBCOMMANDS)[number];
+
+const isSubcommand = (value: string): value is Subcommand =>
+  SUBCOMMANDS.some((subcommand) => subcommand === value);
+
+export const USAGE = `pr-lens canvas <push | pull | rotate> [options]
+
+Keeps a graph document on the PR Lens app as a canvas: a page anyone with the
+link can read, and an SVG a README can embed. The write token lands in
+${REGISTRY_PATH}, which git ignores; the edit link carries the same token
+in its fragment, so share the view link and keep the edit link to yourself.
+
+  pr-lens canvas push [graph.json]     send the document (default ${DEFAULT_SOURCE})
+    --canvas <id|name>                 which canvas (default the one this document
+                                       was pushed to before, else a new one)
+    --name <name>                      what to call a new canvas (default the document's title)
+
+  pr-lens canvas pull [url|id]         fetch the document (default the checkout's only canvas)
+    --canvas <id|name>                 which canvas, when no url or id is given
+    -o, --out <file>                   where to write it (default ${DEFAULT_OUT})
+
+  pr-lens canvas rotate                mint a new write token; the old edit link stops working
+    --canvas <id|name>                 which canvas (default the checkout's only canvas)
+
+  --api <url>                          the PR Lens app (default $${API_ENV}, else ${DEFAULT_API})`;
+
+const readApi = (value: unknown, env: Record<string, string | undefined>): string => {
+  const api = readString(value, "api") ?? env[API_ENV] ?? DEFAULT_API;
+  try {
+    new URL(api);
+  } catch {
+    throw usageError(`--api needs a URL, got ${JSON.stringify(api)}`);
+  }
+  return api.replace(/\/+$/, "");
+};
+
+/** A bare id, or the view link a page shows: {api}/c/{id}, fragment and all. */
+const readCanvasRef = (value: string): { id: string; origin: string | undefined } => {
+  if (isCanvasId(value)) return { id: value, origin: undefined };
+
+  const url = (() => {
+    try {
+      return new URL(value);
+    } catch {
+      throw usageError(`expected a canvas id or a canvas URL, got ${JSON.stringify(value)}`);
+    }
+  })();
+
+  const [, c, last, ...deeper] = url.pathname.split("/");
+  const id = last?.replace(/\.svg$/, "");
+  if (c !== "c" || id === undefined || deeper.length > 0 || !isCanvasId(id))
+    throw usageError(`${value} is not a canvas URL`, "expected {app}/c/{id}");
+  return { id, origin: url.origin };
+};
+
+const countDiagrams = (count: number): string => `${count} ${count === 1 ? "diagram" : "diagrams"}`;
+
+const push = async (
+  args: readonly string[],
+  terminal: Terminal,
+  env: Record<string, string | undefined>,
+): Promise<void> => {
+  const { values, positionals } = parseOptions(args, {
+    canvas: { type: "string" },
+    name: { type: "string" },
+    api: { type: "string" },
+  });
+  if (positionals.length > 1)
+    throw usageError(`push takes one graph document, got ${positionals.length}`);
+
+  const source = positionals[0] ?? DEFAULT_SOURCE;
+  const document = await readGraphDoc(source);
+  const api = readApi(values.api, env);
+  const registry = await readRegistry();
+
+  const ref = readString(values.canvas, "canvas");
+  const known = ref === undefined ? findBySource(registry, source) : findCanvas(registry, ref);
+
+  const target: Registered = await (async () => {
+    if (known !== undefined) return known;
+
+    const minted = await mintCanvas(api);
+    const entry = {
+      name: readString(values.name, "name") ?? document.title,
+      source: sourceKey(source),
+      writeToken: minted.writeToken,
+      rev: minted.rev,
+    };
+    // Recorded before the first push, so a push that fails can be tried again
+    // against the same canvas instead of minting another.
+    registry.canvases[minted.id] = entry;
+    await writeRegistry(registry, terminal);
+    return { id: minted.id, entry };
+  })();
+
+  const pushed = await pushCanvas(api, target.id, target.entry.writeToken, target.entry.rev, document);
+
+  registry.canvases[target.id] = { ...target.entry, source: sourceKey(source), rev: pushed.rev };
+  await writeRegistry(registry, terminal);
+
+  terminal.out(`✓ ${pushed.viewUrl} — rev ${pushed.rev} · ${countDiagrams(pushed.tiles.length)}`);
+  terminal.out(`  edit link, keep it to yourself: ${pushed.editUrl}`);
+  terminal.out(`  README embed: ${pushed.embedUrl}`);
+};
+
+const pull = async (
+  args: readonly string[],
+  terminal: Terminal,
+  env: Record<string, string | undefined>,
+): Promise<void> => {
+  const { values, positionals } = parseOptions(args, {
+    canvas: { type: "string" },
+    out: { type: "string", short: "o" },
+    api: { type: "string" },
+  });
+  if (positionals.length > 1)
+    throw usageError(`pull takes one canvas url or id, got ${positionals.length}`);
+
+  const registry = await readRegistry();
+  const ref = readString(values.canvas, "canvas");
+  const [positional] = positionals;
+
+  const { id, origin } =
+    positional !== undefined
+      ? readCanvasRef(positional)
+      : { id: (ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref)).id, origin: undefined };
+
+  // A pasted link says where it lives; --api still wins when both are given.
+  const explicit = readString(values.api, "api");
+  const api = explicit === undefined && origin !== undefined ? origin : readApi(explicit, env);
+  const out = readString(values.out, "out") ?? DEFAULT_OUT;
+
+  const fetched = await fetchCanvas(api, id);
+  await writeJsonFile(out, fetched.document);
+
+  const entry = registry.canvases[id];
+  if (entry !== undefined) {
+    registry.canvases[id] = { ...entry, rev: fetched.rev };
+    await writeRegistry(registry, terminal);
+  }
+
+  terminal.out(`✓ ${out} — rev ${fetched.rev} of ${fetched.viewUrl}`);
+};
+
+const rotate = async (
+  args: readonly string[],
+  terminal: Terminal,
+  env: Record<string, string | undefined>,
+): Promise<void> => {
+  const { values, positionals } = parseOptions(args, {
+    canvas: { type: "string" },
+    api: { type: "string" },
+  });
+  if (positionals.length > 0)
+    throw usageError(`rotate takes no positional arguments, got ${positionals.join(" ")}`);
+
+  const api = readApi(values.api, env);
+  const registry = await readRegistry();
+  const ref = readString(values.canvas, "canvas");
+  const { id, entry } = ref === undefined ? onlyCanvas(registry) : findCanvas(registry, ref);
+
+  const rotated = await rotateCanvas(api, id, entry.writeToken);
+
+  registry.canvases[id] = { ...entry, writeToken: rotated.writeToken };
+  await writeRegistry(registry, terminal);
+
+  const view = new URL(rotated.editUrl);
+  view.hash = "";
+  terminal.out(`✓ new edit link for ${view.href}: ${rotated.editUrl}`);
+  terminal.out("  the old edit link no longer works");
+};
+
+export const canvasCommand = async (
+  args: readonly string[],
+  terminal: Terminal,
+  env: Record<string, string | undefined>,
+): Promise<void> => {
+  const [name, ...rest] = args;
+  if (name === undefined) throw usageError("canvas needs a subcommand: push, pull or rotate");
+  if (!isSubcommand(name)) throw usageError(`unknown canvas subcommand ${JSON.stringify(name)}`);
+
+  switch (name) {
+    case "push":
+      return push(rest, terminal, env);
+    case "pull":
+      return pull(rest, terminal, env);
+    case "rotate":
+      return rotate(rest, terminal, env);
+    default:
+      return assertNever(name, "Unhandled canvas subcommand");
+  }
+};

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -129,10 +129,27 @@ const settleRotation = async (
   nextToken: string,
   terminal: Terminal,
 ): Promise<{ registered: Registered; editUrl: string }> => {
-  const rotated = await rotateCanvas(api, id, requireWriteToken({ id, entry }), nextToken).catch((error: unknown) => {
-    if (error instanceof PrLensCliError) throw unfinishedRotation(error);
-    throw error;
-  });
+  const rotated = await rotateCanvas(api, id, requireWriteToken({ id, entry }), nextToken).catch(
+    async (error: unknown) => {
+      if (!(error instanceof PrLensCliError)) throw error;
+      if (error.code !== "CANVAS_UNKNOWN") throw unfinishedRotation(error);
+
+      // Conclusive: the app would have said "rotated" if the pending token
+      // were the one on record, so neither it nor the stored token opens
+      // the canvas. The transition is abandoned here, or a token imported
+      // later would carry it out.
+      await updateRegistry((registry) => {
+        const current = registry.canvases[id];
+        if (current === undefined || current.nextWriteToken !== nextToken) return;
+        registry.canvases[id] = { ...current, nextWriteToken: undefined };
+      }, terminal);
+      throw new PrLensCliError(
+        error.code,
+        `${error.message}; the rotation that was pending has been dropped`,
+        error.details,
+      );
+    },
+  );
 
   // Only this transition is closed. A different token pending by now belongs
   // to a later rotation, which will close its own.
@@ -240,27 +257,51 @@ const pull = async (
 
   // An edit link's token is proven before it is written down: an old
   // bookmark from before a rotation must not replace the token that works.
+  // The proof is about the entry as it was read; if another command changes
+  // the entry in the meantime, the proof is stale and is not acted on.
+  const seenToken = registry.canvases[id]?.writeToken;
   const proven = writeToken !== undefined && (await verifyWriteToken(api, id, writeToken));
+
+  type Recorded = "imported" | "kept" | "overtaken" | "refused";
+  const outcome: { recorded: Recorded } = { recorded: "kept" };
 
   // Every pull records the revision, and a proven edit link records its
   // token: a checkout that lost canvas.json, or never had it, gets its pen
-  // back here.
+  // back here. A token that changes hands drops any rotation that was
+  // pending for the old one; that rotation was the old holder's business.
   await updateRegistry((current) => {
     const entry = current.canvases[id];
-    const kept = proven ? writeToken : entry?.writeToken;
+    const untouched = entry?.writeToken === seenToken;
+    const imports = proven && untouched && writeToken !== entry?.writeToken;
+    outcome.recorded =
+      imports ? "imported" : proven && !untouched ? "overtaken" : writeToken !== undefined && !proven ? "refused" : "kept";
+    const kept = imports ? writeToken : entry?.writeToken;
+    const pending = imports ? undefined : entry?.nextWriteToken;
     current.canvases[id] = {
       name: entry?.name ?? fetched.document.title,
       source: entry?.source ?? sourceKey(out),
-      ...(entry?.nextWriteToken === undefined ? {} : { nextWriteToken: entry.nextWriteToken }),
+      ...(pending === undefined ? {} : { nextWriteToken: pending }),
       ...(kept === undefined ? {} : { writeToken: kept }),
       rev: fetched.rev,
     };
   }, terminal);
 
   terminal.out(`✓ ${out} — rev ${fetched.rev} of ${fetched.viewUrl}`);
-  if (proven) terminal.out(`  the edit link's token is now in ${REGISTRY_PATH}`);
-  else if (writeToken !== undefined)
-    terminal.err(`  the edit link's token no longer opens ${id}; nothing was recorded for it`);
+  switch (outcome.recorded) {
+    case "imported":
+      terminal.out(`  the edit link's token is now in ${REGISTRY_PATH}`);
+      return;
+    case "refused":
+      terminal.err(`  the edit link's token no longer opens ${id}; nothing was recorded for it`);
+      return;
+    case "overtaken":
+      terminal.err(`  ${REGISTRY_PATH} changed while the edit link was being checked; its token was not recorded`);
+      return;
+    case "kept":
+      return;
+    default:
+      return assertNever(outcome.recorded, "Unhandled record outcome");
+  }
 };
 
 const rotate = async (

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -1,6 +1,6 @@
 import { assertNever } from "@coldtea/pr-lens-schema";
 import { parseOptions, readString } from "../args.js";
-import { fetchCanvas, mintCanvas, pushCanvas, rotateCanvas } from "../canvas/api.js";
+import { fetchCanvas, mintCanvas, pushCanvas, rotateCanvas, verifyWriteToken } from "../canvas/api.js";
 import {
   ensureRegistryHome,
   findBySource,
@@ -67,8 +67,8 @@ const readApi = (value: unknown, env: Record<string, string | undefined>): strin
 
 type CanvasRef = { id: string; origin: string | undefined; writeToken: string | undefined };
 
-/** What a token in a fragment may be spelled with; anything else is not one. */
-const TOKEN_SHAPE = /^[A-Za-z0-9_-]+$/;
+/** A write token is 128 bits as base64url, the same shape as an id; anything else is not one. */
+const TOKEN_SHAPE = /^[A-Za-z0-9_-]{22}$/;
 
 /**
  * A bare id, or a link a page shows: {app}/c/{id}. An edit link carries the
@@ -93,7 +93,9 @@ const readCanvasRef = (value: string): CanvasRef => {
 
   const fragment = new URLSearchParams(url.hash.replace(/^#/, ""));
   const writeToken = fragment.get("w") ?? undefined;
-  return { id, origin: url.origin, writeToken: writeToken !== undefined && TOKEN_SHAPE.test(writeToken) ? writeToken : undefined };
+  if (writeToken !== undefined && !TOKEN_SHAPE.test(writeToken))
+    throw usageError(`${value} carries something after #w= that is not a write token`, "an edit link ends in #w= and 22 characters");
+  return { id, origin: url.origin, writeToken };
 };
 
 /** The pen for a canvas, or the way to get one. */
@@ -236,21 +238,29 @@ const pull = async (
   const fetched = await fetchCanvas(api, id);
   await writeJsonFile(out, fetched.document);
 
-  // Every pull records the revision, and an edit link records its token: a
-  // checkout that lost canvas.json, or never had it, gets its pen back here.
+  // An edit link's token is proven before it is written down: an old
+  // bookmark from before a rotation must not replace the token that works.
+  const proven = writeToken !== undefined && (await verifyWriteToken(api, id, writeToken));
+
+  // Every pull records the revision, and a proven edit link records its
+  // token: a checkout that lost canvas.json, or never had it, gets its pen
+  // back here.
   await updateRegistry((current) => {
     const entry = current.canvases[id];
+    const kept = proven ? writeToken : entry?.writeToken;
     current.canvases[id] = {
       name: entry?.name ?? fetched.document.title,
       source: entry?.source ?? sourceKey(out),
       ...(entry?.nextWriteToken === undefined ? {} : { nextWriteToken: entry.nextWriteToken }),
-      ...(writeToken ?? entry?.writeToken) === undefined ? {} : { writeToken: writeToken ?? entry?.writeToken },
+      ...(kept === undefined ? {} : { writeToken: kept }),
       rev: fetched.rev,
     };
   }, terminal);
 
   terminal.out(`✓ ${out} — rev ${fetched.rev} of ${fetched.viewUrl}`);
-  if (writeToken !== undefined) terminal.out(`  the edit link's token is now in ${REGISTRY_PATH}`);
+  if (proven) terminal.out(`  the edit link's token is now in ${REGISTRY_PATH}`);
+  else if (writeToken !== undefined)
+    terminal.err(`  the edit link's token no longer opens ${id}; nothing was recorded for it`);
 };
 
 const rotate = async (
@@ -278,6 +288,10 @@ const rotate = async (
   await updateRegistry((current) => {
     const entry = current.canvases[id];
     if (entry === undefined) return;
+    // No pen, no rotation: a pending token written here would be carried
+    // out by the next push once a pen arrives, retiring the very link that
+    // brought it.
+    requireWriteToken({ id, entry });
     const nextWriteToken = entry.nextWriteToken ?? mintWriteToken();
     pending = { id, entry: { ...entry, nextWriteToken } };
     current.canvases[id] = pending.entry;

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -14,7 +14,13 @@ export type CliErrorCode =
   | "MISSING_API_KEY"
   | "PROVIDER_FAILED"
   | "MODEL_OUTPUT_INVALID"
-  | "RENDER_FAILED";
+  | "RENDER_FAILED"
+  | "CANVAS_UNREGISTERED"
+  | "CANVAS_UNKNOWN"
+  | "CANVAS_CONFLICT"
+  | "CANVAS_REJECTED"
+  | "CANVAS_RATE_LIMITED"
+  | "CANVAS_UNAVAILABLE";
 
 export class PrLensCliError extends Error {
   readonly code: CliErrorCode;

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -20,7 +20,8 @@ export type CliErrorCode =
   | "CANVAS_CONFLICT"
   | "CANVAS_REJECTED"
   | "CANVAS_RATE_LIMITED"
-  | "CANVAS_UNAVAILABLE";
+  | "CANVAS_UNAVAILABLE"
+  | "CANVAS_REGISTRY_EXPOSED";
 
 export class PrLensCliError extends Error {
   readonly code: CliErrorCode;

--- a/packages/cli/src/io.ts
+++ b/packages/cli/src/io.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { PrLensCliError } from "./errors.js";
 
@@ -42,14 +42,18 @@ export const writeJsonFile = (path: string, value: unknown): Promise<string> =>
  * owner alone, and replaced in one step so an interrupted write leaves the
  * old copy rather than half of a new one.
  */
+export const secretStagingPath = (path: string): string => `${resolve(path)}.${process.pid}.tmp`;
+
 export const writeSecretJsonFile = async (path: string, value: unknown): Promise<string> => {
   const absolute = resolve(path);
-  const staging = `${absolute}.${process.pid}.tmp`;
+  const staging = secretStagingPath(path);
   try {
     await mkdir(dirname(absolute), { recursive: true });
     await writeFile(staging, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
     await rename(staging, absolute);
   } catch (error) {
+    // Never leave a secret lying about under a temporary name.
+    await unlink(staging).catch(() => undefined);
     throw new PrLensCliError("UNREADABLE_FILE", `cannot write ${path}`, describe(error));
   }
   return absolute;

--- a/packages/cli/src/io.ts
+++ b/packages/cli/src/io.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { PrLensCliError } from "./errors.js";
 
@@ -36,3 +36,21 @@ export const writeTextFile = async (path: string, contents: string): Promise<str
 /** One trailing newline, so written documents behave in a diff and in a shell. */
 export const writeJsonFile = (path: string, value: unknown): Promise<string> =>
   writeTextFile(path, `${JSON.stringify(value, null, 2)}\n`);
+
+/**
+ * A file that holds a secret and nothing else can rebuild: readable by its
+ * owner alone, and replaced in one step so an interrupted write leaves the
+ * old copy rather than half of a new one.
+ */
+export const writeSecretJsonFile = async (path: string, value: unknown): Promise<string> => {
+  const absolute = resolve(path);
+  const staging = `${absolute}.${process.pid}.tmp`;
+  try {
+    await mkdir(dirname(absolute), { recursive: true });
+    await writeFile(staging, `${JSON.stringify(value, null, 2)}\n`, { encoding: "utf8", mode: 0o600 });
+    await rename(staging, absolute);
+  } catch (error) {
+    throw new PrLensCliError("UNREADABLE_FILE", `cannot write ${path}`, describe(error));
+  }
+  return absolute;
+};

--- a/packages/cli/src/workspace.ts
+++ b/packages/cli/src/workspace.ts
@@ -160,13 +160,18 @@ const README = `# .pr-lens
 PR Lens writes its previews here: the diagrams as light and dark SVGs, the
 document they were drawn from, and the manifest describing them.
 
-None of it belongs in a commit. Every file is rebuilt from the diff by
+None of that belongs in a commit. Those files are rebuilt from the diff by
 \`pr-lens analyze\` and \`pr-lens render\`, so a stale copy in the history is
 worth less than nothing — it is a diagram of a pull request somebody already
 merged. What readers are meant to see is the comment on the pull request, or
-the share page it links to.
+the share page it links to. Delete them whenever you like; nothing reads them
+back.
 
-Delete the directory whenever you like. Nothing reads it back.
+One file is different. \`canvas.json\` holds the write token for every canvas
+this checkout has pushed with \`pr-lens canvas push\`, and nothing can rebuild
+it. Without it the canvases stay readable by everyone, but pushing to them
+again needs the edit link you were given. Keep it out of commits and out of
+other people's hands.
 `;
 
 /**

--- a/packages/cli/src/workspace.ts
+++ b/packages/cli/src/workspace.ts
@@ -167,7 +167,7 @@ merged. What readers are meant to see is the comment on the pull request, or
 the share page it links to. Delete them whenever you like; nothing reads them
 back.
 
-One file is different. \`canvas.json\` holds the write token for every canvas
+\`canvas.json\` is the exception. It holds the write token for every canvas
 this checkout has pushed with \`pr-lens canvas push\`, and nothing can rebuild
 it. Without it the canvases stay readable by everyone, but pushing to them
 again needs the edit link you were given. Keep it out of commits and out of

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -70,7 +70,7 @@ const fakeFetch = async (input: string | URL | Request, init?: RequestInit): Pro
   if (method === "POST" && url.pathname === "/api/canvas") {
     minted += 1;
     const id = String(minted).padStart(22, "0");
-    const token = `token-${minted}-a`;
+    const token = `token-${minted}-a`.padEnd(22, "a");
     canvases.set(id, { token, rev: 0, document: undefined });
     return json(201, { id, writeToken: token, rev: 0, ...links(id, token) });
   }
@@ -141,13 +141,14 @@ const registry = async (): Promise<Record<string, { name: string; source: string
   JSON.parse(await readFile(REGISTRY, "utf8")).canvases;
 
 const FIRST = "1".padStart(22, "0");
+const TOKEN1 = "token-1-a".padEnd(22, "a");
 
 test("the first push mints a canvas, records it, and prints the three links", async () => {
   expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
 
   expect(out).toEqual([
     `✓ ${API}/c/${FIRST} — rev 1 · 2 diagrams`,
-    `  edit link, keep it to yourself: ${API}/c/${FIRST}#w=token-1-a`,
+    `  edit link, keep it to yourself: ${API}/c/${FIRST}#w=${TOKEN1}`,
     `  README embed: ${API}/c/${FIRST}.svg`,
   ]);
 
@@ -155,7 +156,7 @@ test("the first push mints a canvas, records it, and prints the three links", as
     [FIRST]: {
       name: "Batch broadcast sending through Postmark",
       source: "drawn.graph.json",
-      writeToken: "token-1-a",
+      writeToken: TOKEN1,
       rev: 1,
     },
   });
@@ -244,13 +245,13 @@ test("rotate mints the next token here, and the old one stops opening the door",
 
   const next = (await registry())[FIRST]?.writeToken;
   expect(next).toMatch(/^[A-Za-z0-9_-]{22}$/);
-  expect(next).not.toBe("token-1-a");
+  expect(next).not.toBe(TOKEN1);
   expect((await registry())[FIRST]).not.toHaveProperty("nextWriteToken");
   expect(out).toEqual([
     `✓ new edit link for ${API}/c/${FIRST}: ${API}/c/${FIRST}#w=${next}`,
     "  the old edit link no longer works",
   ]);
-  expect(seen[0]?.headers.get("authorization")).toBe("Bearer token-1-a");
+  expect(seen[0]?.headers.get("authorization")).toBe(`Bearer ${TOKEN1}`);
   expect(seen[0]?.body).toEqual({ writeToken: next });
 
   // The app now knows only the new token, and the registry sends that one.
@@ -268,7 +269,7 @@ test("a rotation whose answer was lost is finished by the next command", async (
   expect(err.join("\n")).toContain("the rotation is not finished");
 
   const pending = (await registry())[FIRST];
-  expect(pending?.writeToken).toBe("token-1-a");
+  expect(pending?.writeToken).toBe(TOKEN1);
   expect(pending?.nextWriteToken).toMatch(/^[A-Za-z0-9_-]{22}$/);
 
   err = [];
@@ -472,18 +473,55 @@ test("pulling an edit link brings its token into a checkout that never had it", 
   out = [];
   seen = [];
 
-  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=token-1-a`)).toBe(0);
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${TOKEN1}`)).toBe(0);
   expect(out).toEqual([`✓ .pr-lens/graph.json — rev 1 of ${API}/c/${FIRST}`, "  the edit link's token is now in .pr-lens/canvas.json"]);
   expect((await registry())[FIRST]).toEqual({
     name: "Batch broadcast sending through Postmark",
     source: ".pr-lens/graph.json",
-    writeToken: "token-1-a",
+    writeToken: TOKEN1,
     rev: 1,
   });
 
   expect(await invoke("canvas", "push", "drawn.graph.json", "--canvas", FIRST, "--api", API)).toBe(0);
-  expect(seen.at(-1)?.headers.get("authorization")).toBe("Bearer token-1-a");
+  expect(seen.at(-1)?.headers.get("authorization")).toBe(`Bearer ${TOKEN1}`);
   expect((await registry())[FIRST]?.rev).toBe(2);
+});
+
+test("pulling an edit link that no longer opens the canvas keeps the token that does", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  expect(await invoke("canvas", "rotate", "--api", API)).toBe(0);
+  const current = (await registry())[FIRST]?.writeToken;
+  err = [];
+
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${TOKEN1}`)).toBe(0);
+  expect(err.join("\n")).toContain("no longer opens");
+  expect((await registry())[FIRST]?.writeToken).toBe(current);
+});
+
+test("a link with something that is not a token after #w= is a misuse", async () => {
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=A`)).toBe(2);
+  expect(seen).toEqual([]);
+});
+
+test("rotate on a canvas pulled by its view link leaves nothing pending behind", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const fresh = await mkdtemp(join(tmpdir(), "pr-lens-canvas-other-"));
+  process.chdir(fresh);
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}`)).toBe(0);
+
+  expect(await invoke("canvas", "rotate", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("[CANVAS_UNREGISTERED]");
+  expect((await registry())[FIRST]).not.toHaveProperty("nextWriteToken");
+
+  // The edit link arrives later; nothing retires it on the next push. (The
+  // pull itself proves the token with a rotation onto itself, which is not
+  // a rotation; the push after it must send none at all.)
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${TOKEN1}`)).toBe(0);
+  await writeFile("drawn.graph.json", await readFile(GOLDEN, "utf8"), "utf8");
+  seen = [];
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--canvas", FIRST, "--api", API)).toBe(0);
+  expect(seen.map((request) => [request.method, request.path.endsWith("/rotate")])).toEqual([["PUT", false]]);
+  expect(seen[0]?.headers.get("authorization")).toBe(`Bearer ${TOKEN1}`);
 });
 
 test("pulling a view link records the revision, and push then asks for the edit link", async () => {

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -524,6 +524,73 @@ test("rotate on a canvas pulled by its view link leaves nothing pending behind",
   expect(seen[0]?.headers.get("authorization")).toBe(`Bearer ${TOKEN1}`);
 });
 
+test("a proof made against one entry is not acted on once another command has changed it", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const other = "other-token".padEnd(22, "b");
+  const entries = await registry();
+
+  // The proof succeeds; then, before the pull writes, a rotate elsewhere
+  // lands a different token in the registry and on the app.
+  const proving = fakeFetch;
+  vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(input instanceof Request ? input.url : String(input));
+    const answer = await proving(input, init);
+    if (url.pathname.endsWith("/rotate")) {
+      await writeFile(REGISTRY, JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], writeToken: other } } }), "utf8");
+      canvases.get(FIRST)!.token = other;
+    }
+    return answer;
+  });
+
+  err = [];
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${TOKEN1}`)).toBe(0);
+  expect(err.join("\n")).toContain("changed while the edit link was being checked");
+  expect((await registry())[FIRST]?.writeToken).toBe(other);
+});
+
+test("a rotation the app has refused for good is dropped, not carried out by a later pen", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const gone = "gone".padEnd(22, "g");
+  const pending = "pending".padEnd(22, "p");
+  const current = "current".padEnd(22, "c");
+  const entries = await registry();
+  await writeFile(
+    REGISTRY,
+    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], writeToken: gone, nextWriteToken: pending } } }),
+    "utf8",
+  );
+  canvases.get(FIRST)!.token = current;
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("the rotation that was pending has been dropped");
+  expect((await registry())[FIRST]).not.toHaveProperty("nextWriteToken");
+
+  seen = [];
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${current}`)).toBe(0);
+  seen = [];
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  expect(seen.map((request) => [request.method, request.path.endsWith("/rotate")])).toEqual([["PUT", false]]);
+  expect(canvases.get(FIRST)?.token).toBe(current);
+});
+
+test("importing a token drops a rotation that was pending for the old one", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const pending = "pending".padEnd(22, "p");
+  const current = "current".padEnd(22, "c");
+  const entries = await registry();
+  await writeFile(
+    REGISTRY,
+    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], nextWriteToken: pending } } }),
+    "utf8",
+  );
+  canvases.get(FIRST)!.token = current;
+
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${current}`)).toBe(0);
+  const entry = (await registry())[FIRST];
+  expect(entry?.writeToken).toBe(current);
+  expect(entry).not.toHaveProperty("nextWriteToken");
+});
+
 test("pulling a view link records the revision, and push then asks for the edit link", async () => {
   expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
   const fresh = await mkdtemp(join(tmpdir(), "pr-lens-canvas-other-"));

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -138,7 +138,7 @@ afterEach(() => {
 });
 
 const registry = async (): Promise<
-  Record<string, { name: string; source: string; writeToken?: string; pending?: { writeToken: string; api: string }; rev: number }>
+  Record<string, { name: string; source: string; api: string; writeToken?: string; pending?: string; rev: number }>
 > =>
   JSON.parse(await readFile(REGISTRY, "utf8")).canvases;
 
@@ -158,6 +158,7 @@ test("the first push mints a canvas, records it, and prints the three links", as
     [FIRST]: {
       name: "Batch broadcast sending through Postmark",
       source: "drawn.graph.json",
+      api: API,
       writeToken: TOKEN1,
       rev: 1,
     },
@@ -272,7 +273,7 @@ test("a rotation whose answer was lost is finished by the next command", async (
 
   const pending = (await registry())[FIRST];
   expect(pending?.writeToken).toBe(TOKEN1);
-  expect(pending?.pending).toEqual({ writeToken: expect.stringMatching(/^[A-Za-z0-9_-]{22}$/), api: API });
+  expect(pending?.pending).toMatch(/^[A-Za-z0-9_-]{22}$/);
 
   err = [];
   seen = [];
@@ -282,7 +283,7 @@ test("a rotation whose answer was lost is finished by the next command", async (
     ["PUT", false],
   ]);
   const settled = (await registry())[FIRST];
-  expect(settled?.writeToken).toBe(pending?.pending?.writeToken);
+  expect(settled?.writeToken).toBe(pending?.pending);
   expect(settled).not.toHaveProperty("pending");
   expect(seen[1]?.headers.get("authorization")).toBe(`Bearer ${settled?.writeToken}`);
 });
@@ -480,6 +481,7 @@ test("pulling an edit link brings its token into a checkout that never had it", 
   expect((await registry())[FIRST]).toEqual({
     name: "Batch broadcast sending through Postmark",
     source: ".pr-lens/graph.json",
+    api: API,
     writeToken: TOKEN1,
     rev: 1,
   });
@@ -558,7 +560,7 @@ test("a rotation the app has refused for good is dropped, not carried out by a l
   const entries = await registry();
   await writeFile(
     REGISTRY,
-    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], writeToken: gone, pending: { writeToken: pending, api: API } } } }),
+    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], writeToken: gone, pending } } }),
     "utf8",
   );
   canvases.get(FIRST)!.token = current;
@@ -582,7 +584,7 @@ test("importing a token drops a rotation that was pending for the old one", asyn
   const entries = await registry();
   await writeFile(
     REGISTRY,
-    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], pending: { writeToken: pending, api: API } } } }),
+    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], pending } } }),
     "utf8",
   );
   canvases.get(FIRST)!.token = current;
@@ -593,27 +595,63 @@ test("importing a token drops a rotation that was pending for the old one", asyn
   expect(entry).not.toHaveProperty("pending");
 });
 
-test("a rotation pending against another app is neither carried out nor dropped here", async () => {
+test("an entry answers only for the app it was made against", async () => {
   expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
   const pending = "pending".padEnd(22, "p");
   const entries = await registry();
   await writeFile(
     REGISTRY,
-    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], pending: { writeToken: pending, api: "https://staging.test" } } } }),
+    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], api: "https://staging.test", pending } } }),
     "utf8",
   );
+  const before = (await registry())[FIRST];
 
+  // Neither push nor rotate here may act on it, and nothing changes.
   err = [];
   seen = [];
-  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
-  expect(seen.map((request) => [request.method, request.path.endsWith("/rotate")])).toEqual([["PUT", false]]);
-  expect(err.join("\n")).toContain("still pending against https://staging.test");
-  expect((await registry())[FIRST]?.pending).toEqual({ writeToken: pending, api: "https://staging.test" });
-
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--canvas", FIRST, "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("registered against https://staging.test");
+  expect(seen).toEqual([]);
   err = [];
   expect(await invoke("canvas", "rotate", "--api", API)).toBe(1);
-  expect(err.join("\n")).toContain("finish it there first");
-  expect((await registry())[FIRST]?.pending).toEqual({ writeToken: pending, api: "https://staging.test" });
+  expect(err.join("\n")).toContain("registered against https://staging.test");
+  expect((await registry())[FIRST]).toEqual(before);
+
+  // A pull of the same id from this app leaves that entry alone too, even
+  // with a token this app vouches for.
+  err = [];
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${TOKEN1}`)).toBe(0);
+  expect(err.join("\n")).toContain("registered against another app");
+  expect((await registry())[FIRST]).toEqual(before);
+});
+
+test("a minted canvas whose token cannot be written down is handed to the terminal", async () => {
+  // The moment the app mints, the registry path becomes a directory: the
+  // write that follows the mint fails, and the mint has already happened.
+  const minting = fakeFetch;
+  vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+    const answer = await minting(input, init);
+    if (init?.method === "POST") await mkdir(REGISTRY, { recursive: true });
+    return answer;
+  });
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  const reported = err.join("\n");
+  expect(reported).toContain("the canvas was minted and its token is not saved");
+  expect(reported).toContain(`${API}/c/${FIRST}#w=${TOKEN1}`);
+  expect(seen.map((request) => request.method)).toEqual(["POST"]);
+});
+
+test("pull will not write a document over the registry", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const entries = await registry();
+
+  for (const target of [REGISTRY, `./${REGISTRY}`, `${REGISTRY}.lock`]) {
+    err = [];
+    expect(await invoke("canvas", "pull", "-o", target, "--api", API)).toBe(2);
+    expect(err.join("\n")).toContain("write tokens live");
+  }
+  expect(await registry()).toEqual(entries);
 });
 
 test("pulling a view link records the revision, and push then asks for the edit link", async () => {
@@ -626,6 +664,7 @@ test("pulling a view link records the revision, and push then asks for the edit 
   expect((await registry())[FIRST]).toEqual({
     name: "Batch broadcast sending through Postmark",
     source: ".pr-lens/graph.json",
+    api: API,
     rev: 1,
   });
 

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, stat, unlink, utimes, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, stat, symlink, unlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -137,7 +137,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-const registry = async (): Promise<Record<string, { name: string; source: string; writeToken: string; nextWriteToken?: string; rev: number }>> =>
+const registry = async (): Promise<Record<string, { name: string; source: string; writeToken?: string; nextWriteToken?: string; rev: number }>> =>
   JSON.parse(await readFile(REGISTRY, "utf8")).canvases;
 
 const FIRST = "1".padStart(22, "0");
@@ -228,7 +228,7 @@ test("pull takes the view link as it was shared, fragment included", async () =>
   seen = [];
   out = [];
 
-  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=whatever`, "-o", "pulled.json")).toBe(0);
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#v=371,80,0.414`, "-o", "pulled.json")).toBe(0);
 
   expect(seen[0]?.path).toBe(`/api/canvas/${FIRST}`);
   expect(out).toEqual([`✓ pulled.json — rev 1 of ${API}/c/${FIRST}`]);
@@ -462,4 +462,51 @@ test("a document the renderer refuses is a rejection with the app's own words", 
   const reported = err.join("\n");
   expect(reported).toContain("[CANVAS_REJECTED]");
   expect(reported).toContain("The document has nothing the canvas can draw");
+});
+
+test("pulling an edit link brings its token into a checkout that never had it", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const fresh = await mkdtemp(join(tmpdir(), "pr-lens-canvas-other-"));
+  process.chdir(fresh);
+  await writeFile("drawn.graph.json", await readFile(GOLDEN, "utf8"), "utf8");
+  out = [];
+  seen = [];
+
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=token-1-a`)).toBe(0);
+  expect(out).toEqual([`✓ .pr-lens/graph.json — rev 1 of ${API}/c/${FIRST}`, "  the edit link's token is now in .pr-lens/canvas.json"]);
+  expect((await registry())[FIRST]).toEqual({
+    name: "Batch broadcast sending through Postmark",
+    source: ".pr-lens/graph.json",
+    writeToken: "token-1-a",
+    rev: 1,
+  });
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--canvas", FIRST, "--api", API)).toBe(0);
+  expect(seen.at(-1)?.headers.get("authorization")).toBe("Bearer token-1-a");
+  expect((await registry())[FIRST]?.rev).toBe(2);
+});
+
+test("pulling a view link records the revision, and push then asks for the edit link", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const fresh = await mkdtemp(join(tmpdir(), "pr-lens-canvas-other-"));
+  process.chdir(fresh);
+  await writeFile("drawn.graph.json", await readFile(GOLDEN, "utf8"), "utf8");
+
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}`)).toBe(0);
+  expect((await registry())[FIRST]).toEqual({
+    name: "Batch broadcast sending through Postmark",
+    source: ".pr-lens/graph.json",
+    rev: 1,
+  });
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--canvas", FIRST, "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("pull its edit link");
+});
+
+test("a checkout whose .git is a dangling link is not outside a repository", async () => {
+  await symlink("nowhere", ".git");
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("[CANVAS_REGISTRY_EXPOSED]");
+  expect(seen).toEqual([]);
 });

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -298,29 +298,43 @@ test("two commands changing the registry at once both keep their canvas", async 
   expect(Object.values(entries).map((entry) => entry.source).sort()).toEqual(["drawn.graph.json", "other.json"]);
 });
 
-test("a lock left behind by a dead command is taken over, once", async () => {
+/** A pid nothing is running under: the largest Linux allows, which macOS never reaches. */
+const DEAD_PID = 4194304;
+
+test("a lock left behind by a command that is gone is taken over", async () => {
   const lock = `${REGISTRY}.lock`;
   await mkdir(".pr-lens", { recursive: true });
-  await writeFile(lock, "gone.deadbeef", "utf8");
-  const longAgo = new Date(Date.now() - 60_000);
-  await utimes(lock, longAgo, longAgo);
+  await writeFile(lock, `${DEAD_PID}:deadbeef`, "utf8");
 
   expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
   await expect(stat(lock)).rejects.toThrow();
 });
 
-test("a lock somebody else holds is waited for, not removed", async () => {
+test("a lock held by a command that is still running is waited for, however old, not removed", async () => {
   const lock = `${REGISTRY}.lock`;
   await mkdir(".pr-lens", { recursive: true });
-  await writeFile(lock, "other.cafebabe", "utf8");
+  await writeFile(lock, `${process.pid}:cafebabe`, "utf8");
+  const longAgo = new Date(Date.now() - 600_000);
+  await utimes(lock, longAgo, longAgo);
 
   const pushing = invoke("canvas", "push", "drawn.graph.json", "--api", API);
-  await new Promise((resolve) => setTimeout(resolve, 200));
-  expect((await registry().catch(() => ({})))).toEqual({});
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  expect(await registry().catch(() => ({}))).toEqual({});
+  expect(await readFile(lock, "utf8")).toBe(`${process.pid}:cafebabe`);
   await unlink(lock);
 
   expect(await pushing).toBe(0);
   expect(Object.keys(await registry())).toHaveLength(1);
+});
+
+test("git failing for any reason but absence refuses to write the registry", async () => {
+  await sh("git", ["init", "--quiet"], { cwd: process.cwd() });
+  await writeFile(".git/config", "[core]\n\tthis is not a config\n", "utf8");
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("[CANVAS_REGISTRY_EXPOSED]");
+  expect(seen).toEqual([]);
+  await expect(readFile(REGISTRY, "utf8")).rejects.toThrow();
 });
 
 test("the registry is refused a home git would commit", async () => {

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -137,7 +137,9 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-const registry = async (): Promise<Record<string, { name: string; source: string; writeToken?: string; nextWriteToken?: string; rev: number }>> =>
+const registry = async (): Promise<
+  Record<string, { name: string; source: string; writeToken?: string; pending?: { writeToken: string; api: string }; rev: number }>
+> =>
   JSON.parse(await readFile(REGISTRY, "utf8")).canvases;
 
 const FIRST = "1".padStart(22, "0");
@@ -246,7 +248,7 @@ test("rotate mints the next token here, and the old one stops opening the door",
   const next = (await registry())[FIRST]?.writeToken;
   expect(next).toMatch(/^[A-Za-z0-9_-]{22}$/);
   expect(next).not.toBe(TOKEN1);
-  expect((await registry())[FIRST]).not.toHaveProperty("nextWriteToken");
+  expect((await registry())[FIRST]).not.toHaveProperty("pending");
   expect(out).toEqual([
     `✓ new edit link for ${API}/c/${FIRST}: ${API}/c/${FIRST}#w=${next}`,
     "  the old edit link no longer works",
@@ -270,7 +272,7 @@ test("a rotation whose answer was lost is finished by the next command", async (
 
   const pending = (await registry())[FIRST];
   expect(pending?.writeToken).toBe(TOKEN1);
-  expect(pending?.nextWriteToken).toMatch(/^[A-Za-z0-9_-]{22}$/);
+  expect(pending?.pending).toEqual({ writeToken: expect.stringMatching(/^[A-Za-z0-9_-]{22}$/), api: API });
 
   err = [];
   seen = [];
@@ -280,8 +282,8 @@ test("a rotation whose answer was lost is finished by the next command", async (
     ["PUT", false],
   ]);
   const settled = (await registry())[FIRST];
-  expect(settled?.writeToken).toBe(pending?.nextWriteToken);
-  expect(settled).not.toHaveProperty("nextWriteToken");
+  expect(settled?.writeToken).toBe(pending?.pending?.writeToken);
+  expect(settled).not.toHaveProperty("pending");
   expect(seen[1]?.headers.get("authorization")).toBe(`Bearer ${settled?.writeToken}`);
 });
 
@@ -511,7 +513,7 @@ test("rotate on a canvas pulled by its view link leaves nothing pending behind",
 
   expect(await invoke("canvas", "rotate", "--api", API)).toBe(1);
   expect(err.join("\n")).toContain("[CANVAS_UNREGISTERED]");
-  expect((await registry())[FIRST]).not.toHaveProperty("nextWriteToken");
+  expect((await registry())[FIRST]).not.toHaveProperty("pending");
 
   // The edit link arrives later; nothing retires it on the next push. (The
   // pull itself proves the token with a rotation onto itself, which is not
@@ -556,14 +558,14 @@ test("a rotation the app has refused for good is dropped, not carried out by a l
   const entries = await registry();
   await writeFile(
     REGISTRY,
-    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], writeToken: gone, nextWriteToken: pending } } }),
+    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], writeToken: gone, pending: { writeToken: pending, api: API } } } }),
     "utf8",
   );
   canvases.get(FIRST)!.token = current;
 
   expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
   expect(err.join("\n")).toContain("the rotation that was pending has been dropped");
-  expect((await registry())[FIRST]).not.toHaveProperty("nextWriteToken");
+  expect((await registry())[FIRST]).not.toHaveProperty("pending");
 
   seen = [];
   expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${current}`)).toBe(0);
@@ -580,7 +582,7 @@ test("importing a token drops a rotation that was pending for the old one", asyn
   const entries = await registry();
   await writeFile(
     REGISTRY,
-    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], nextWriteToken: pending } } }),
+    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], pending: { writeToken: pending, api: API } } } }),
     "utf8",
   );
   canvases.get(FIRST)!.token = current;
@@ -588,7 +590,30 @@ test("importing a token drops a rotation that was pending for the old one", asyn
   expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${current}`)).toBe(0);
   const entry = (await registry())[FIRST];
   expect(entry?.writeToken).toBe(current);
-  expect(entry).not.toHaveProperty("nextWriteToken");
+  expect(entry).not.toHaveProperty("pending");
+});
+
+test("a rotation pending against another app is neither carried out nor dropped here", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const pending = "pending".padEnd(22, "p");
+  const entries = await registry();
+  await writeFile(
+    REGISTRY,
+    JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], pending: { writeToken: pending, api: "https://staging.test" } } } }),
+    "utf8",
+  );
+
+  err = [];
+  seen = [];
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  expect(seen.map((request) => [request.method, request.path.endsWith("/rotate")])).toEqual([["PUT", false]]);
+  expect(err.join("\n")).toContain("still pending against https://staging.test");
+  expect((await registry())[FIRST]?.pending).toEqual({ writeToken: pending, api: "https://staging.test" });
+
+  err = [];
+  expect(await invoke("canvas", "rotate", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("finish it there first");
+  expect((await registry())[FIRST]?.pending).toEqual({ writeToken: pending, api: "https://staging.test" });
 });
 
 test("pulling a view link records the revision, and push then asks for the edit link", async () => {

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, stat, unlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -137,7 +137,7 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-const registry = async (): Promise<Record<string, { name: string; source: string; writeToken: string; rev: number }>> =>
+const registry = async (): Promise<Record<string, { name: string; source: string; writeToken: string; nextWriteToken?: string; rev: number }>> =>
   JSON.parse(await readFile(REGISTRY, "utf8")).canvases;
 
 const FIRST = "1".padStart(22, "0");
@@ -298,6 +298,31 @@ test("two commands changing the registry at once both keep their canvas", async 
   expect(Object.values(entries).map((entry) => entry.source).sort()).toEqual(["drawn.graph.json", "other.json"]);
 });
 
+test("a lock left behind by a dead command is taken over, once", async () => {
+  const lock = `${REGISTRY}.lock`;
+  await mkdir(".pr-lens", { recursive: true });
+  await writeFile(lock, "gone.deadbeef", "utf8");
+  const longAgo = new Date(Date.now() - 60_000);
+  await utimes(lock, longAgo, longAgo);
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  await expect(stat(lock)).rejects.toThrow();
+});
+
+test("a lock somebody else holds is waited for, not removed", async () => {
+  const lock = `${REGISTRY}.lock`;
+  await mkdir(".pr-lens", { recursive: true });
+  await writeFile(lock, "other.cafebabe", "utf8");
+
+  const pushing = invoke("canvas", "push", "drawn.graph.json", "--api", API);
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  expect((await registry().catch(() => ({})))).toEqual({});
+  await unlink(lock);
+
+  expect(await pushing).toBe(0);
+  expect(Object.keys(await registry())).toHaveLength(1);
+});
+
 test("the registry is refused a home git would commit", async () => {
   await sh("git", ["init", "--quiet"], { cwd: process.cwd() });
   await writeFile(".gitignore", "!.pr-lens/\n", "utf8");
@@ -306,6 +331,23 @@ test("the registry is refused a home git would commit", async () => {
   expect(err.join("\n")).toContain("[CANVAS_REGISTRY_EXPOSED]");
   expect(seen).toEqual([]);
   await expect(readFile(REGISTRY, "utf8")).rejects.toThrow();
+
+  // Ignoring the registry alone is not enough: it is staged through a
+  // sibling name, and a crash would leave the tokens there.
+  await writeFile(".gitignore", "!.pr-lens/\n.pr-lens/canvas.json\n", "utf8");
+  err = [];
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("[CANVAS_REGISTRY_EXPOSED]");
+  expect(seen).toEqual([]);
+});
+
+test("rotate prints the link the app answered with, not one guessed from --api", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", `${API}/`)).toBe(0);
+  out = [];
+
+  expect(await invoke("canvas", "rotate", "--api", `${API}/`)).toBe(0);
+  const next = (await registry())[FIRST]?.writeToken;
+  expect(out[0]).toBe(`✓ new edit link for ${API}/c/${FIRST}: ${API}/c/${FIRST}#w=${next}`);
 });
 
 test("a document the app would refuse is refused with its reasons", async () => {

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -1,0 +1,298 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { run } from "../src/cli.js";
+import type { Terminal } from "../src/terminal.js";
+
+const GOLDEN = new URL("../../schema/examples/postmark-refactor.graph.json", import.meta.url).pathname;
+const API = "https://canvas.test";
+const REGISTRY = ".pr-lens/canvas.json";
+
+let out: string[] = [];
+let err: string[] = [];
+const terminal: Terminal = { out: (line) => out.push(line), err: (line) => err.push(line) };
+
+const invoke = (...argv: string[]) => run(argv, terminal, {});
+
+/**
+ * The app, in memory: four routes, the same envelope and the same refusals.
+ * Every request is kept so a test can say what was sent.
+ */
+type Stored = { token: string; rev: number; document: unknown };
+type Seen = { method: string; path: string; headers: Headers; body: unknown };
+
+let canvases = new Map<string, Stored>();
+let seen: Seen[] = [];
+let minted = 0;
+
+const json = (status: number, body: unknown): Response =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+const refuse = (status: number, code: string, message: string, extra: Record<string, unknown> = {}) =>
+  json(status, { error: { code, message, ...extra } });
+
+const links = (id: string, token?: string) => ({
+  viewUrl: `${API}/c/${id}`,
+  embedUrl: `${API}/c/${id}.svg`,
+  ...(token === undefined ? {} : { editUrl: `${API}/c/${id}#w=${token}` }),
+});
+
+const tile = (id: string) => ({
+  id,
+  title: id,
+  lens: "architecture",
+  crumbs: ["overview"],
+  hero: id === "view:overview",
+  width: 800,
+  height: 600,
+  renders: { light: `${id}-light.svg`, dark: `${id}-dark.svg` },
+  images: { light: `${API}/i/${id}-light.svg`, dark: `${API}/i/${id}-dark.svg` },
+});
+
+const TILES = [tile("view:overview"), tile("view:new-batch-path")];
+
+const bearer = (headers: Headers): string | undefined =>
+  headers.get("authorization")?.replace(/^Bearer /, "");
+
+const fakeFetch = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+  const url = new URL(input instanceof Request ? input.url : String(input));
+  const method = init?.method ?? "GET";
+  const headers = new Headers(init?.headers);
+  const body = typeof init?.body === "string" ? JSON.parse(init.body) : undefined;
+  seen.push({ method, path: url.pathname, headers, body });
+
+  if (method === "POST" && url.pathname === "/api/canvas") {
+    minted += 1;
+    const id = String(minted).padStart(22, "0");
+    const token = `token-${minted}-a`;
+    canvases.set(id, { token, rev: 0, document: undefined });
+    return json(201, { id, writeToken: token, rev: 0, ...links(id, token) });
+  }
+
+  const [, , , id, action] = url.pathname.split("/");
+  const canvas = id === undefined ? undefined : canvases.get(id);
+  if (id === undefined || canvas === undefined) return refuse(404, "NOT_FOUND", "There is no canvas here");
+
+  if (method === "GET" && action === undefined) {
+    if (canvas.document === undefined) return refuse(404, "NOT_FOUND", "There is no canvas here");
+    return json(200, { id, rev: canvas.rev, ...links(id), document: canvas.document, tiles: TILES });
+  }
+
+  if (bearer(headers) !== canvas.token) return refuse(404, "NOT_FOUND", "There is no canvas here");
+
+  if (method === "POST" && action === "rotate") {
+    canvas.token = `${canvas.token}-rotated`;
+    return json(200, { id, writeToken: canvas.token, editUrl: `${API}/c/${id}#w=${canvas.token}` });
+  }
+
+  if (method === "PUT" && action === undefined) {
+    if (headers.get("if-match") !== String(canvas.rev))
+      return refuse(409, "REVISION_MOVED", "The canvas has moved on since you pulled it", { rev: canvas.rev });
+    if (typeof body !== "object" || body === null || !("lanes" in body))
+      return refuse(422, "INVALID_DOCUMENT", "The document does not match the PR Lens contract", {
+        issues: [{ code: "INVALID_DOCUMENT", path: "lanes", message: "expected array, received undefined" }],
+      });
+    canvas.rev += 1;
+    canvas.document = body;
+    return json(200, { id, rev: canvas.rev, ...links(id, canvas.token), tiles: TILES });
+  }
+
+  return refuse(404, "NOT_FOUND", "There is no canvas here");
+};
+
+const originalCwd = process.cwd();
+
+beforeEach(async () => {
+  out = [];
+  err = [];
+  canvases = new Map();
+  seen = [];
+  minted = 0;
+  vi.stubGlobal("fetch", fakeFetch);
+
+  const directory = await mkdtemp(join(tmpdir(), "pr-lens-canvas-"));
+  process.chdir(directory);
+  await writeFile("drawn.graph.json", await readFile(GOLDEN, "utf8"), "utf8");
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  vi.unstubAllGlobals();
+});
+
+const registry = async (): Promise<Record<string, { name: string; source: string; writeToken: string; rev: number }>> =>
+  JSON.parse(await readFile(REGISTRY, "utf8")).canvases;
+
+const FIRST = "1".padStart(22, "0");
+
+test("the first push mints a canvas, records it, and prints the three links", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+
+  expect(out).toEqual([
+    `✓ ${API}/c/${FIRST} — rev 1 · 2 diagrams`,
+    `  edit link, keep it to yourself: ${API}/c/${FIRST}#w=token-1-a`,
+    `  README embed: ${API}/c/${FIRST}.svg`,
+  ]);
+
+  expect(await registry()).toEqual({
+    [FIRST]: {
+      name: "Batch broadcast sending through Postmark",
+      source: "drawn.graph.json",
+      writeToken: "token-1-a",
+      rev: 1,
+    },
+  });
+
+  expect(seen.map((request) => request.method)).toEqual(["POST", "PUT"]);
+  expect(seen[1]?.headers.get("if-match")).toBe("0");
+  expect(seen[1]?.headers.get("user-agent")).toMatch(/^pr-lens-cli\//);
+});
+
+test("a second push of the same file reuses the canvas and sends the rev it last saw", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  seen = [];
+
+  expect(await invoke("canvas", "push", "./drawn.graph.json", "--api", API)).toBe(0);
+
+  expect(seen.map((request) => request.method)).toEqual(["PUT"]);
+  expect(seen[0]?.headers.get("if-match")).toBe("1");
+  expect((await registry())[FIRST]?.rev).toBe(2);
+  expect(canvases.size).toBe(1);
+});
+
+test("a rev the app has moved past is a conflict, and says what to do", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const canvas = canvases.get(FIRST);
+  if (canvas !== undefined) canvas.rev = 5;
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+
+  const reported = err.join("\n");
+  expect(reported).toContain("[CANVAS_CONFLICT]");
+  expect(reported).toContain("rev 5");
+  expect(reported).toContain("pr-lens canvas pull, then push again");
+});
+
+test("--canvas takes the name a canvas was minted under", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--name", "architecture", "--api", API)).toBe(0);
+  await writeFile("other.graph.json", await readFile(GOLDEN, "utf8"), "utf8");
+  seen = [];
+
+  expect(await invoke("canvas", "push", "other.graph.json", "--canvas", "architecture", "--api", API)).toBe(0);
+
+  expect(seen.map((request) => request.method)).toEqual(["PUT"]);
+  expect(seen[0]?.path).toBe(`/api/canvas/${FIRST}`);
+  expect((await registry())[FIRST]).toMatchObject({ name: "architecture", source: "other.graph.json", rev: 2 });
+});
+
+test("a name nobody minted is not a canvas this checkout knows", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--canvas", "nope", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("[CANVAS_UNREGISTERED]");
+  expect(seen).toEqual([]);
+});
+
+test("pull writes the document and brings the recorded rev up to date", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const canvas = canvases.get(FIRST);
+  if (canvas !== undefined) canvas.rev = 3;
+  out = [];
+
+  expect(await invoke("canvas", "pull", "--api", API)).toBe(0);
+
+  expect(out).toEqual([`✓ .pr-lens/graph.json — rev 3 of ${API}/c/${FIRST}`]);
+  expect(JSON.parse(await readFile(".pr-lens/graph.json", "utf8"))).toEqual(
+    JSON.parse(await readFile(GOLDEN, "utf8")),
+  );
+  expect((await registry())[FIRST]?.rev).toBe(3);
+});
+
+test("pull takes the view link as it was shared, fragment included", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  seen = [];
+  out = [];
+
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=whatever`, "-o", "pulled.json")).toBe(0);
+
+  expect(seen[0]?.path).toBe(`/api/canvas/${FIRST}`);
+  expect(out).toEqual([`✓ pulled.json — rev 1 of ${API}/c/${FIRST}`]);
+  expect(JSON.parse(await readFile("pulled.json", "utf8"))).toHaveProperty("lanes");
+});
+
+test("rotate replaces the token, and the old one stops opening the door", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  out = [];
+
+  expect(await invoke("canvas", "rotate", "--api", API)).toBe(0);
+
+  expect(out).toEqual([
+    `✓ new edit link for ${API}/c/${FIRST}: ${API}/c/${FIRST}#w=token-1-a-rotated`,
+    "  the old edit link no longer works",
+  ]);
+  expect((await registry())[FIRST]?.writeToken).toBe("token-1-a-rotated");
+
+  const stale = JSON.parse(await readFile(REGISTRY, "utf8"));
+  stale.canvases[FIRST].writeToken = "token-1-a";
+  await writeFile(REGISTRY, JSON.stringify(stale), "utf8");
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  const reported = err.join("\n");
+  expect(reported).toContain("[CANVAS_UNKNOWN]");
+  expect(reported).toContain("or the token is wrong");
+});
+
+test("a document the app would refuse is refused with its reasons", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+
+  // The CLI validates before it sends, so a document the fake would refuse
+  // never reaches it. Refuse the next push outright instead.
+  vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+    if (init?.method !== "PUT") return fakeFetch(input, init);
+    return refuse(422, "INVALID_DOCUMENT", "The document does not match the PR Lens contract", {
+      issues: [
+        { code: "INVALID_DOCUMENT", path: "lanes", message: "expected array, received undefined" },
+        { code: "INVALID_DOCUMENT", path: "", message: "the document names no lens" },
+      ],
+    });
+  });
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  const reported = err.join("\n");
+  expect(reported).toContain("[CANVAS_REJECTED]");
+  expect(reported).toContain("The document does not match the PR Lens contract");
+  expect(reported).toContain("lanes: expected array, received undefined");
+  expect(reported).toContain("\nthe document names no lens");
+});
+
+test("an invalid local document fails before anything is sent", async () => {
+  const broken = JSON.parse(await readFile(GOLDEN, "utf8"));
+  delete broken.lanes;
+  await writeFile("broken.json", JSON.stringify(broken), "utf8");
+
+  expect(await invoke("canvas", "push", "broken.json", "--api", API)).toBe(1);
+
+  expect(err.join("\n")).toContain("[INVALID_DOCUMENT]");
+  expect(seen).toEqual([]);
+});
+
+test("pull with nothing registered says how to get a canvas", async () => {
+  expect(await invoke("canvas", "pull", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("[CANVAS_UNREGISTERED]");
+  expect(seen).toEqual([]);
+});
+
+test("canvas --help and canvas push --help both print the usage", async () => {
+  expect(await invoke("canvas", "--help")).toBe(0);
+  expect(out.join("\n")).toContain("pr-lens canvas push");
+
+  out = [];
+  expect(await invoke("canvas", "push", "--help")).toBe(0);
+  expect(out.join("\n")).toContain("--canvas <id|name>");
+});
+
+test("a subcommand that is not one is a misuse", async () => {
+  expect(await invoke("canvas", "publish")).toBe(2);
+  const reported = err.join("\n");
+  expect(reported).toContain('unknown canvas subcommand "publish"');
+  expect(reported).toContain("pr-lens canvas <push | pull | rotate>");
+});

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
@@ -93,6 +93,8 @@ const fakeFetch = async (input: string | URL | Request, init?: RequestInit): Pro
       return refuse(422, "INVALID_DOCUMENT", "The document does not match the PR Lens contract", {
         issues: [{ code: "INVALID_DOCUMENT", path: "lanes", message: "expected array, received undefined" }],
       });
+    if ("title" in body && body.title === "Nothing to draw")
+      return refuse(422, "CANNOT_DRAW", "The document has nothing the canvas can draw");
     canvas.rev += 1;
     canvas.document = body;
     return json(200, { id, rev: canvas.rev, ...links(id, canvas.token), tiles: TILES });
@@ -295,4 +297,24 @@ test("a subcommand that is not one is a misuse", async () => {
   const reported = err.join("\n");
   expect(reported).toContain('unknown canvas subcommand "publish"');
   expect(reported).toContain("pr-lens canvas <push | pull | rotate>");
+});
+
+test("the registry is the owner's alone, and replaced whole", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+
+  const mode = (await stat(REGISTRY)).mode & 0o777;
+  expect(mode.toString(8)).toBe("600");
+  await expect(stat(`${REGISTRY}.${process.pid}.tmp`)).rejects.toThrow();
+});
+
+test("a document the renderer refuses is a rejection with the app's own words", async () => {
+  const empty = JSON.parse(await readFile(GOLDEN, "utf8"));
+  empty.title = "Nothing to draw";
+  await writeFile("empty.json", JSON.stringify(empty), "utf8");
+
+  expect(await invoke("canvas", "push", "empty.json", "--api", API)).toBe(1);
+
+  const reported = err.join("\n");
+  expect(reported).toContain("[CANVAS_REJECTED]");
+  expect(reported).toContain("The document has nothing the canvas can draw");
 });

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -301,13 +301,27 @@ test("two commands changing the registry at once both keep their canvas", async 
 /** A pid nothing is running under: the largest Linux allows, which macOS never reaches. */
 const DEAD_PID = 4194304;
 
-test("a lock left behind by a command that is gone is taken over", async () => {
+test("a lock left behind by a command that is gone is reported, with the way out, never taken over", async () => {
   const lock = `${REGISTRY}.lock`;
   await mkdir(".pr-lens", { recursive: true });
   await writeFile(lock, `${DEAD_PID}:deadbeef`, "utf8");
 
-  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
-  await expect(stat(lock)).rejects.toThrow();
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  const reported = err.join("\n");
+  expect(reported).toContain(`locked by pid ${DEAD_PID}, which is no longer running`);
+  expect(reported).toContain(`remove ${lock}`);
+  expect(await readFile(lock, "utf8")).toBe(`${DEAD_PID}:deadbeef`);
+  await expect(readFile(REGISTRY, "utf8")).rejects.toThrow();
+});
+
+test("a lock with nobody written in it is reported the same way", async () => {
+  const lock = `${REGISTRY}.lock`;
+  await mkdir(".pr-lens", { recursive: true });
+  await writeFile(lock, "", "utf8");
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("did not finish taking it");
+  await expect(readFile(REGISTRY, "utf8")).rejects.toThrow();
 });
 
 test("a lock held by a command that is still running is waited for, however old, not removed", async () => {
@@ -325,6 +339,16 @@ test("a lock held by a command that is still running is waited for, however old,
 
   expect(await pushing).toBe(0);
   expect(Object.keys(await registry())).toHaveLength(1);
+});
+
+test("a checkout git cannot read is not outside a repository", async () => {
+  await sh("git", ["init", "--quiet"], { cwd: process.cwd() });
+  await unlink(".git/HEAD");
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("[CANVAS_REGISTRY_EXPOSED]");
+  expect(seen).toEqual([]);
+  await expect(readFile(REGISTRY, "utf8")).rejects.toThrow();
 });
 
 test("git failing for any reason but absence refuses to write the registry", async () => {

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -1,9 +1,13 @@
+import { execFile } from "node:child_process";
 import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { run } from "../src/cli.js";
 import type { Terminal } from "../src/terminal.js";
+
+const sh = promisify(execFile);
 
 const GOLDEN = new URL("../../schema/examples/postmark-refactor.graph.json", import.meta.url).pathname;
 const API = "https://canvas.test";
@@ -25,6 +29,7 @@ type Seen = { method: string; path: string; headers: Headers; body: unknown };
 let canvases = new Map<string, Stored>();
 let seen: Seen[] = [];
 let minted = 0;
+let loseNextAnswer = false;
 
 const json = (status: number, body: unknown): Response =>
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
@@ -79,12 +84,20 @@ const fakeFetch = async (input: string | URL | Request, init?: RequestInit): Pro
     return json(200, { id, rev: canvas.rev, ...links(id), document: canvas.document, tiles: TILES });
   }
 
-  if (bearer(headers) !== canvas.token) return refuse(404, "NOT_FOUND", "There is no canvas here");
-
   if (method === "POST" && action === "rotate") {
-    canvas.token = `${canvas.token}-rotated`;
-    return json(200, { id, writeToken: canvas.token, editUrl: `${API}/c/${id}#w=${canvas.token}` });
+    const next = typeof body === "object" && body !== null && "writeToken" in body ? body.writeToken : undefined;
+    if (typeof next !== "string" || !/^[A-Za-z0-9_-]{22}$/.test(next))
+      return refuse(400, "INVALID_REQUEST", "The body must carry the new writeToken");
+    if (bearer(headers) === canvas.token) canvas.token = next;
+    else if (next !== canvas.token) return refuse(404, "NOT_FOUND", "There is no canvas here");
+    if (loseNextAnswer) {
+      loseNextAnswer = false;
+      throw new TypeError("fetch failed");
+    }
+    return json(200, { id, editUrl: `${API}/c/${id}#w=${canvas.token}` });
   }
+
+  if (bearer(headers) !== canvas.token) return refuse(404, "NOT_FOUND", "There is no canvas here");
 
   if (method === "PUT" && action === undefined) {
     if (headers.get("if-match") !== String(canvas.rev))
@@ -111,6 +124,7 @@ beforeEach(async () => {
   canvases = new Map();
   seen = [];
   minted = 0;
+  loseNextAnswer = false;
   vi.stubGlobal("fetch", fakeFetch);
 
   const directory = await mkdtemp(join(tmpdir(), "pr-lens-canvas-"));
@@ -221,26 +235,77 @@ test("pull takes the view link as it was shared, fragment included", async () =>
   expect(JSON.parse(await readFile("pulled.json", "utf8"))).toHaveProperty("lanes");
 });
 
-test("rotate replaces the token, and the old one stops opening the door", async () => {
+test("rotate mints the next token here, and the old one stops opening the door", async () => {
   expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
   out = [];
+  seen = [];
 
   expect(await invoke("canvas", "rotate", "--api", API)).toBe(0);
 
+  const next = (await registry())[FIRST]?.writeToken;
+  expect(next).toMatch(/^[A-Za-z0-9_-]{22}$/);
+  expect(next).not.toBe("token-1-a");
+  expect((await registry())[FIRST]).not.toHaveProperty("nextWriteToken");
   expect(out).toEqual([
-    `✓ new edit link for ${API}/c/${FIRST}: ${API}/c/${FIRST}#w=token-1-a-rotated`,
+    `✓ new edit link for ${API}/c/${FIRST}: ${API}/c/${FIRST}#w=${next}`,
     "  the old edit link no longer works",
   ]);
-  expect((await registry())[FIRST]?.writeToken).toBe("token-1-a-rotated");
+  expect(seen[0]?.headers.get("authorization")).toBe("Bearer token-1-a");
+  expect(seen[0]?.body).toEqual({ writeToken: next });
 
-  const stale = JSON.parse(await readFile(REGISTRY, "utf8"));
-  stale.canvases[FIRST].writeToken = "token-1-a";
-  await writeFile(REGISTRY, JSON.stringify(stale), "utf8");
+  // The app now knows only the new token, and the registry sends that one.
+  out = [];
+  seen = [];
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  expect(seen[0]?.headers.get("authorization")).toBe(`Bearer ${next}`);
+});
+
+test("a rotation whose answer was lost is finished by the next command", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  loseNextAnswer = true;
+
+  expect(await invoke("canvas", "rotate", "--api", API)).toBe(1);
+  expect(err.join("\n")).toContain("the rotation is not finished");
+
+  const pending = (await registry())[FIRST];
+  expect(pending?.writeToken).toBe("token-1-a");
+  expect(pending?.nextWriteToken).toMatch(/^[A-Za-z0-9_-]{22}$/);
+
+  err = [];
+  seen = [];
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  expect(seen.map((request) => [request.method, request.path.endsWith("/rotate")])).toEqual([
+    ["POST", true],
+    ["PUT", false],
+  ]);
+  const settled = (await registry())[FIRST];
+  expect(settled?.writeToken).toBe(pending?.nextWriteToken);
+  expect(settled).not.toHaveProperty("nextWriteToken");
+  expect(seen[1]?.headers.get("authorization")).toBe(`Bearer ${settled?.writeToken}`);
+});
+
+test("two commands changing the registry at once both keep their canvas", async () => {
+  await writeFile("other.json", await readFile(GOLDEN, "utf8"), "utf8");
+
+  const [first, second] = await Promise.all([
+    invoke("canvas", "push", "drawn.graph.json", "--api", API),
+    invoke("canvas", "push", "other.json", "--api", API),
+  ]);
+  expect([first, second]).toEqual([0, 0]);
+
+  const entries = await registry();
+  expect(Object.keys(entries)).toHaveLength(2);
+  expect(Object.values(entries).map((entry) => entry.source).sort()).toEqual(["drawn.graph.json", "other.json"]);
+});
+
+test("the registry is refused a home git would commit", async () => {
+  await sh("git", ["init", "--quiet"], { cwd: process.cwd() });
+  await writeFile(".gitignore", "!.pr-lens/\n", "utf8");
 
   expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
-  const reported = err.join("\n");
-  expect(reported).toContain("[CANVAS_UNKNOWN]");
-  expect(reported).toContain("or the token is wrong");
+  expect(err.join("\n")).toContain("[CANVAS_REGISTRY_EXPOSED]");
+  expect(seen).toEqual([]);
+  await expect(readFile(REGISTRY, "utf8")).rejects.toThrow();
 });
 
 test("a document the app would refuse is refused with its reasons", async () => {

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -566,7 +566,7 @@ test("a rotation the app has refused for good is dropped, not carried out by a l
   canvases.get(FIRST)!.token = current;
 
   expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
-  expect(err.join("\n")).toContain("the rotation that was pending has been dropped");
+  expect(err.join("\n")).toContain("the pending rotation was dropped");
   expect((await registry())[FIRST]).not.toHaveProperty("pending");
 
   seen = [];

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdir, mkdtemp, readFile, stat, symlink, unlink, utimes, writeFile } from "node:fs/promises";
+import { chmod, link, mkdir, mkdtemp, readFile, rm, stat, symlink, unlink, utimes, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -642,15 +642,77 @@ test("a minted canvas whose token cannot be written down is handed to the termin
   expect(seen.map((request) => request.method)).toEqual(["POST"]);
 });
 
+test("an edit link for a canvas nobody has pushed to is registered, and the push then lands", async () => {
+  // The mint's answer was the only copy of the token, kept from the terminal.
+  const minting = fakeFetch;
+  vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+    const answer = await minting(input, init);
+    if (init?.method === "POST") await mkdir(REGISTRY, { recursive: true });
+    return answer;
+  });
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  vi.stubGlobal("fetch", fakeFetch);
+  await rm(REGISTRY, { recursive: true });
+  out = [];
+  seen = [];
+
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${TOKEN1}`)).toBe(0);
+  expect(out).toEqual([`✓ ${FIRST} has nothing pushed to it yet; its token is now in .pr-lens/canvas.json`]);
+  expect((await registry())[FIRST]).toEqual({ name: FIRST, source: ".pr-lens/drawn.graph.json", api: API, writeToken: TOKEN1, rev: 0 });
+
+  seen = [];
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--canvas", FIRST, "--api", API)).toBe(0);
+  expect(seen.map((request) => request.method)).toEqual(["PUT"]);
+  expect(seen[0]?.headers.get("if-match")).toBe("0");
+  expect((await registry())[FIRST]?.rev).toBe(1);
+});
+
+test("a connection that fails is reported in the CLI's words, not the runtime's", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  vi.stubGlobal("fetch", async () => {
+    throw new TypeError("fetch failed: connect ECONNREFUSED 127.0.0.1:1 (https://canvas.test/api/canvas?secret=1)");
+  });
+  err = [];
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  const reported = err.join("\n");
+  expect(reported).toContain("[CANVAS_UNAVAILABLE]");
+  expect(reported).toContain("did not answer");
+  expect(reported).not.toContain("ECONNREFUSED");
+  expect(reported).not.toContain("secret=1");
+});
+
+test("a filesystem that will not take the lock is a typed failure, not a crash", async () => {
+  await mkdir(".pr-lens", { recursive: true });
+  await chmod(".pr-lens", 0o500);
+  try {
+    // Whichever write the read-only directory refuses first, the workspace
+    // README or the lock, the answer is the typed file error, not a trace.
+    expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+    const reported = err.join("\n");
+    expect(reported).toContain("[UNREADABLE_FILE]");
+    expect(reported).toMatch(/cannot (write|take the lock)/);
+    expect(reported).not.toContain("    at ");
+  } finally {
+    await chmod(".pr-lens", 0o700);
+  }
+});
+
 test("pull will not write a document over the registry", async () => {
   expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
   const entries = await registry();
 
-  for (const target of [REGISTRY, `./${REGISTRY}`, `${REGISTRY}.lock`]) {
+  for (const target of [REGISTRY, `./${REGISTRY}`, `${REGISTRY}.lock`, ".pr-lens/Canvas.json", ".pr-lens/CANVAS.JSON"]) {
     err = [];
     expect(await invoke("canvas", "pull", "-o", target, "--api", API)).toBe(2);
     expect(err.join("\n")).toContain("write tokens live");
   }
+  expect(await registry()).toEqual(entries);
+
+  // A hard link to the registry is the registry.
+  await link(REGISTRY, "alias.json");
+  err = [];
+  expect(await invoke("canvas", "pull", "-o", "alias.json", "--api", API)).toBe(2);
   expect(await registry()).toEqual(entries);
 });
 

--- a/packages/cli/test/canvas.test.ts
+++ b/packages/cli/test/canvas.test.ts
@@ -657,7 +657,7 @@ test("an edit link for a canvas nobody has pushed to is registered, and the push
   seen = [];
 
   expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${TOKEN1}`)).toBe(0);
-  expect(out).toEqual([`✓ ${FIRST} has nothing pushed to it yet; its token is now in .pr-lens/canvas.json`]);
+  expect(out).toEqual([`✓ ${FIRST} has nothing pushed to it yet`, "  the edit link's token is now in .pr-lens/canvas.json"]);
   expect((await registry())[FIRST]).toEqual({ name: FIRST, source: ".pr-lens/drawn.graph.json", api: API, writeToken: TOKEN1, rev: 0 });
 
   seen = [];
@@ -665,6 +665,48 @@ test("an edit link for a canvas nobody has pushed to is registered, and the push
   expect(seen.map((request) => request.method)).toEqual(["PUT"]);
   expect(seen[0]?.headers.get("if-match")).toBe("0");
   expect((await registry())[FIRST]?.rev).toBe(1);
+});
+
+test("pulling an unpushed canvas's own link again keeps a rotation that is pending on it", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  const pending = "pending".padEnd(22, "p");
+  const entries = await registry();
+  await writeFile(REGISTRY, JSON.stringify({ canvases: { [FIRST]: { ...entries[FIRST], rev: 0, pending } } }), "utf8");
+  canvases.get(FIRST)!.document = undefined;
+
+  expect(await invoke("canvas", "pull", `${API}/c/${FIRST}#w=${TOKEN1}`)).toBe(0);
+  const entry = (await registry())[FIRST];
+  expect(entry?.writeToken).toBe(TOKEN1);
+  expect(entry?.pending).toBe(pending);
+});
+
+test("pull refuses the registry's names in a checkout that has no workspace yet", async () => {
+  for (const target of [REGISTRY, ".pr-lens/Canvas.json", `${REGISTRY}.lock`]) {
+    err = [];
+    expect(await invoke("canvas", "pull", `${API}/c/${FIRST}`, "-o", target)).toBe(2);
+    expect(err.join("\n")).toContain("write tokens live");
+  }
+  expect(seen).toEqual([]);
+  await expect(stat(".pr-lens")).rejects.toThrow();
+});
+
+test("a connection that dies after the headers is reported in the CLI's words too", async () => {
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(0);
+  vi.stubGlobal("fetch", async () => ({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    text: async () => {
+      throw new TypeError("terminated: other side closed (10.0.0.7:443)");
+    },
+  }));
+  err = [];
+
+  expect(await invoke("canvas", "push", "drawn.graph.json", "--api", API)).toBe(1);
+  const reported = err.join("\n");
+  expect(reported).toContain("[CANVAS_UNAVAILABLE]");
+  expect(reported).toContain("cut off");
+  expect(reported).not.toContain("10.0.0.7");
 });
 
 test("a connection that fails is reported in the CLI's words, not the runtime's", async () => {

--- a/packages/cli/test/workspace.test.ts
+++ b/packages/cli/test/workspace.test.ts
@@ -231,7 +231,7 @@ test("render leaves its previews in the workspace, ignored and explained", async
     "assets",
   );
   expect(await readFile(join(directory, WORKSPACE_DIR, "README.md"), "utf8")).toContain(
-    "None of it belongs in a commit",
+    "None of that belongs in a commit",
   );
   expect(await ignoresPreviews(directory, join(directory, WORKSPACE_DIR))).toBe(true);
 });


### PR DESCRIPTION
Adds a `canvas` command so a rendered document can live on prlens.dev as a
  shareable page and a README embed.

```
      pr-lens canvas push              # .pr-lens/drawn.graph.json → https://prlens.dev/c/{id}
      pr-lens canvas pull <url|id>     # the document back into .pr-lens/graph.json
      pr-lens canvas rotate            # a new write token; the old edit link stops working
```

 `push` sends the JSON document, never SVG. The first push mints a canvas, later pushes update it, and a push that has been overtaken is refused. 

Write tokens live in `.pr-lens/canvas.json`: written 0600 under a lock, refused anywhere git could commit them, and recoverable by pulling the edit link.

Failures carry stable codes (`CANVAS_UNKNOWN`, `CANVAS_CONFLICT`, `CANVAS_REJECTED`, `CANVAS_UNREGISTERED`, `CANVAS_RATE_LIMITED`, `CANVAS_UNAVAILABLE`, `CANVAS_REGISTRY_EXPOSED`), and the CLI never prints a transport error's own text