### PR TITLE
✨ feat(cli): project graph views as Mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,12 @@ npx @coldtea/pr-lens-cli render .pr-lens/graph.json
 open .pr-lens/*-dark-*.svg    # macOS; the SVGs are self-contained, any browser reads them
 ```
 
+For a terminal-native view of the same evidence graph, project one view as Mermaid:
+
+```bash
+npx @coldtea/pr-lens-cli mermaid .pr-lens/graph.json --view overview
+```
+
 This is also the shape of reviewing an agent's work: while you read the diff, the agent that wrote it renders it. With the skill installed, "render this change with PR Lens and open the SVGs" gets you the diagram beside the diff, the same picture its pull request will carry, minutes earlier.
 
 </details>
@@ -316,8 +322,8 @@ This is also the shape of reviewing an agent's work: while you read the diff, th
 | Package                                        | What it is                                                                                           |
 | ---------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
 | [`packages/schema`](packages/schema)           | `@coldtea/pr-lens-schema`: the contract every other component speaks                                 |
-| [`packages/renderer`](packages/renderer)       | `@coldtea/pr-lens-renderer`: deterministic JSON graph → the animated, theme-paired SVGs on this page |
-| [`packages/cli`](packages/cli)                 | `@coldtea/pr-lens-cli`: read a diff with your own model key, render it, compose the comment          |
+| [`packages/renderer`](packages/renderer)       | `@coldtea/pr-lens-renderer`: deterministic graph projection to animated SVG or static Mermaid        |
+| [`packages/cli`](packages/cli)                 | `@coldtea/pr-lens-cli`: read a diff, project it for web or terminal, and compose the comment          |
 | [`packages/action`](packages/action)           | the GitHub Action: analyze, publish, post one static comment                                         |
 | [`packages/agent-skill`](packages/agent-skill) | `@coldtea/pr-lens-agent-skill`: teaches a coding agent to draw the change it just made               |
 

--- a/packages/action/action.yml
+++ b/packages/action/action.yml
@@ -35,7 +35,7 @@ inputs:
     default: pr-lens
   cli-version:
     description: Version of @coldtea/pr-lens-cli to run.
-    default: 0.2.0
+    default: 0.3.0
   comment-author:
     description: >-
       Login that owns the PR Lens comment. Only a comment posted by this

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -10,7 +10,7 @@ npx @coldtea/pr-lens-cli analyze --base origin/main
 
 ## Bring your own key
 
-Only `analyze` talks to a model; `render`, `comment`, `validate`, `export` and `canvas` never do. Its key is read from the environment, never from a flag: a flag lands in shell history and in the log of whatever CI runs it. The diff goes to the provider you name and nowhere else: there is no PR Lens service in this path.
+Only `analyze` talks to a model; `render`, `mermaid`, `comment`, `validate`, `export` and `canvas` never do. Its key is read from the environment, never from a flag: a flag lands in shell history and in the log of whatever CI runs it. The diff goes to the provider you name and nowhere else: there is no PR Lens service in this path.
 
 ```bash
 export GEMINI_API_KEY=…      # Gemini is the default, not a requirement
@@ -75,6 +75,16 @@ Both matter to what comes next. The manifest is where `comment` gets its file na
 
 The SVGs carry no script and no external reference, and the same document renders to the same bytes every time. `--theme light` or `--theme dark` draws one half of the pair.
 
+### `mermaid`
+
+```bash
+pr-lens mermaid .pr-lens/graph.json --view send-pipeline -o send-pipeline.mmd
+```
+
+Projects one selected view as Mermaid source for a terminal. A view supplies its own lens. For a document without views, or for a whole-document projection, use `--lens architecture` or `--lens data-flow` instead. If a document declares several lenses and neither option settles the choice, the command asks you to choose rather than guessing.
+
+This is a second projection of the same graph, not a second analysis path. It applies the same repository corrections as `render`, preserves graph and message order, escapes graph labels before putting them into Mermaid syntax, and produces the same bytes for the same input. It writes to stdout unless `--out` names a file.
+
 ### `comment`
 
 ```bash
@@ -132,7 +142,7 @@ The CLI refuses to write the registry where git could commit it. If a checkout t
 
 ## Corrections
 
-A repository's `.github/pr-lens.yml` is picked up automatically by `render` and applied at draw time: renames, exclusions, lane pins, groupings. It is an overlay: inference never writes back into it, so a correction keeps holding as the code moves and the model renames things between runs, and the document on disk stays the record of what was inferred.
+A repository's `.github/pr-lens.yml` is picked up automatically by `render` and `mermaid` and applied at projection time: renames, exclusions, lane pins, groupings. It is an overlay: inference never writes back into it, so a correction keeps holding as the code moves and the model renames things between runs, and the document on disk stays the record of what was inferred.
 
 ```yaml
 schemaVersion: 0.1.0
@@ -146,7 +156,7 @@ map:
 
 A lane pin may name a lane the document never declared; the band is created and takes the id for its label. And `render` reports any correction that changed nothing about what it drew. A config that has drifted, usually because the file a selector named has moved, otherwise fails silently and forever.
 
-`--config` points elsewhere and `--no-config` ignores it, on both `render` and `analyze`. `analyze` reads only `lenses` from it, since which lenses to fill is a question for extraction and the rest is a question for drawing.
+`--config` points elsewhere and `--no-config` ignores it on `render`, `mermaid` and `analyze`. `analyze` reads only `lenses` from it, since which lenses to fill is a question for extraction and the rest is a question for projection.
 
 ## Failures
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coldtea/pr-lens-cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "The PR Lens command line: turn a pull request diff into a schema-valid graph with your own model key, render it, and compose the comment.",
   "license": "MIT",
   "author": "Coldtea AI",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -3,13 +3,14 @@ import { analyzeCommand, USAGE as ANALYZE_USAGE } from "./commands/analyze.js";
 import { canvasCommand, USAGE as CANVAS_USAGE } from "./commands/canvas.js";
 import { commentCommand, USAGE as COMMENT_USAGE } from "./commands/comment.js";
 import { exportCommand, USAGE as EXPORT_USAGE } from "./commands/export.js";
+import { mermaidCommand, USAGE as MERMAID_USAGE } from "./commands/mermaid.js";
 import { renderCommand, USAGE as RENDER_USAGE } from "./commands/render.js";
 import { USAGE as VALIDATE_USAGE, validateCommand } from "./commands/validate.js";
 import { formatError, PrLensCliError } from "./errors.js";
 import type { Terminal } from "./terminal.js";
 import { CLI_VERSION } from "./version.js";
 
-const COMMANDS = ["analyze", "render", "comment", "validate", "export", "canvas"] as const;
+const COMMANDS = ["analyze", "render", "mermaid", "comment", "validate", "export", "canvas"] as const;
 type CommandName = (typeof COMMANDS)[number];
 
 const isCommand = (value: string): value is CommandName =>
@@ -19,6 +20,7 @@ const HELP = `pr-lens — review what actually matters
 
   pr-lens analyze   --base <ref>            a diff, read by your own model, as a graph document
   pr-lens render    <graph.json>            that document, as light and dark SVGs
+  pr-lens mermaid   <graph.json>            one view, as Mermaid for a terminal
   pr-lens comment   --graph --manifest      the pull request comment, as markdown
   pr-lens validate  <file...>               any PR Lens document, checked against the contract
   pr-lens export    <graph.json>            the merged state, as a map worth committing
@@ -36,6 +38,8 @@ const usageFor = (command: CommandName): string => {
       return ANALYZE_USAGE;
     case "render":
       return RENDER_USAGE;
+    case "mermaid":
+      return MERMAID_USAGE;
     case "comment":
       return COMMENT_USAGE;
     case "validate":
@@ -60,6 +64,8 @@ const dispatch = (
       return analyzeCommand(args, terminal, env);
     case "render":
       return renderCommand(args, terminal);
+    case "mermaid":
+      return mermaidCommand(args, terminal);
     case "comment":
       return commentCommand(args, terminal);
     case "validate":

--- a/packages/cli/src/commands/mermaid.ts
+++ b/packages/cli/src/commands/mermaid.ts
@@ -1,0 +1,135 @@
+import {
+  applyCorrections,
+  findView,
+  PrLensRenderError,
+  renderMermaid,
+} from "@coldtea/pr-lens-renderer";
+import {
+  safeParseGraphDoc,
+  type Config,
+  type GraphDoc,
+  type Lens,
+} from "@coldtea/pr-lens-schema";
+import { expectOne, parseOptions, readBoolean, readString } from "../args.js";
+import { discoverConfig, loadConfig } from "../config-file.js";
+import { unmatchedCorrections } from "../corrections.js";
+import { readGraphDoc } from "../document.js";
+import { PrLensCliError, usageError } from "../errors.js";
+import { repositoryRoot } from "../git.js";
+import { writeTextFile } from "../io.js";
+import type { Terminal } from "../terminal.js";
+
+export const USAGE = `pr-lens mermaid <graph.json> [options]
+
+Projects one architecture or data-flow diagram from the evidence graph as
+Mermaid source for terminal rendering. Select a view to infer its lens, or
+name the lens when projecting the whole document.
+
+  -o, --out <file>    write Mermaid source to this file (default stdout)
+      --lens <lens>   architecture | data-flow
+      --view <id>     project one named view and infer its lens
+      --config <file> apply these repository corrections
+      --no-config     ignore the repository's corrections`;
+
+const readLens = (value: unknown): Lens | undefined => {
+  const lens = readString(value, "lens");
+  switch (lens) {
+    case undefined:
+      return undefined;
+    case "architecture":
+    case "data-flow":
+      return lens;
+    default:
+      throw usageError(
+        `--lens takes architecture or data-flow, got ${JSON.stringify(lens)}`,
+      );
+  }
+};
+
+const selectedLens = (graph: GraphDoc, requested: Lens | undefined, viewId: string | undefined): Lens => {
+  if (viewId !== undefined) {
+    const view = findView(graph.views, viewId);
+    if (view === undefined)
+      throw new PrLensCliError("RENDER_FAILED", `this document has no view '${viewId}' [UNKNOWN_VIEW]`);
+    if (requested !== undefined && requested !== view.lens)
+      throw usageError(
+        `view '${viewId}' uses the '${view.lens}' lens, not '${requested}'`,
+      );
+    return view.lens;
+  }
+
+  if (requested !== undefined) return requested;
+  if (graph.lenses.length === 1) {
+    const lens = graph.lenses[0];
+    if (lens !== undefined) return lens;
+  }
+
+  throw usageError("--lens is required when the document declares several lenses and no view is selected");
+};
+
+const correct = (graph: GraphDoc, config: Config): GraphDoc => {
+  let corrected: GraphDoc;
+  try {
+    corrected = applyCorrections(graph, config.map);
+  } catch (error) {
+    if (!(error instanceof PrLensRenderError)) throw error;
+    throw new PrLensCliError("RENDER_FAILED", `${error.message} [${error.code}]`);
+  }
+
+  const parsed = safeParseGraphDoc(corrected);
+  if (!parsed.ok)
+    throw new PrLensCliError(
+      "INVALID_DOCUMENT",
+      `the configured document no longer validates [${parsed.error.code}]`,
+      parsed.error.message,
+    );
+  return parsed.value;
+};
+
+export const mermaidCommand = async (
+  args: readonly string[],
+  terminal: Terminal,
+): Promise<void> => {
+  const { values, positionals } = parseOptions(args, {
+    out: { type: "string", short: "o" },
+    lens: { type: "string" },
+    view: { type: "string" },
+    config: { type: "string" },
+    "no-config": { type: "boolean" },
+  });
+
+  const graph = await readGraphDoc(expectOne(positionals, "one graph document to project"));
+  const configPath = readString(values.config, "config");
+  const configured = readBoolean(values["no-config"])
+    ? undefined
+    : configPath === undefined
+      ? await discoverConfig(await repositoryRoot(process.cwd()).catch(() => process.cwd()))
+      : await loadConfig(configPath);
+
+  const prepared = (() => {
+    if (configured === undefined) return graph;
+    for (const warning of unmatchedCorrections(graph, configured.config))
+      terminal.err(`${configured.path}: ${warning}`);
+    return correct(graph, configured.config);
+  })();
+
+  const view = readString(values.view, "view");
+  const lens = selectedLens(prepared, readLens(values.lens), view);
+  const diagram = (() => {
+    try {
+      return renderMermaid(prepared, { lens, view });
+    } catch (error) {
+      if (!(error instanceof PrLensRenderError)) throw error;
+      throw new PrLensCliError("RENDER_FAILED", `${error.message} [${error.code}]`);
+    }
+  })();
+
+  const out = readString(values.out, "out");
+  if (out === undefined) {
+    terminal.out(diagram.trimEnd());
+    return;
+  }
+
+  const written = await writeTextFile(out, diagram);
+  terminal.out(`✓ wrote ${written} as Mermaid ${lens}`);
+};

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,4 +1,4 @@
 /** Recorded on every document this CLI produces, as the generator's version. */
-export const CLI_VERSION = "0.2.0";
+export const CLI_VERSION = "0.3.0";
 
 export const GENERATOR_NAME = "pr-lens-cli";

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -10,6 +10,8 @@ import type { Terminal } from "../src/terminal.js";
 import { CLI_VERSION } from "../src/version.js";
 
 const GOLDEN = new URL("../../schema/examples/postmark-refactor.graph.json", import.meta.url).pathname;
+const MINIMAL = new URL("../../schema/examples/minimal.graph.json", import.meta.url).pathname;
+const CONFIG = new URL("../../schema/examples/pr-lens.config.json", import.meta.url).pathname;
 
 let out: string[] = [];
 let err: string[] = [];
@@ -30,6 +32,7 @@ test("running it with nothing to do is a misuse, and prints what it can do", asy
 test("--help is an answer, not a misuse", async () => {
   expect(await invoke("--help")).toBe(0);
   expect(out.join("\n")).toContain("pr-lens validate");
+  expect(out.join("\n")).toContain("pr-lens mermaid");
 });
 
 test("--version is the version stamped on documents", async () => {
@@ -45,6 +48,83 @@ test("an unknown command is a misuse", async () => {
 test("a command's --help prints that command's usage", async () => {
   expect(await invoke("analyze", "--help")).toBe(0);
   expect(out.join("\n")).toContain("--api-key-env");
+});
+
+test("mermaid writes one selected view for terminal rendering", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "pr-lens-mermaid-"));
+  const target = join(directory, "flow.mmd");
+
+  expect(
+    await invoke(
+      "mermaid",
+      GOLDEN,
+      "--view",
+      "send-pipeline-view",
+      "--out",
+      target,
+      "--no-config",
+    ),
+  ).toBe(0);
+
+  const diagram = await readFile(target, "utf8");
+  expect(diagram).toMatch(/^sequenceDiagram\n/);
+  expect(diagram).toContain("enqueue broadcast job (modified)");
+  expect(out.join("\n")).toContain(target);
+});
+
+test("mermaid requires a lens when a document has several and no view was selected", async () => {
+  expect(await invoke("mermaid", GOLDEN, "--no-config")).toBe(2);
+  expect(err.join("\n")).toContain("--lens is required");
+});
+
+test("mermaid infers a document's only lens and writes to stdout", async () => {
+  expect(await invoke("mermaid", MINIMAL, "--no-config")).toBe(0);
+  expect(out.join("\n")).toMatch(/^flowchart LR/);
+});
+
+test("mermaid applies repository corrections before projecting", async () => {
+  expect(
+    await invoke("mermaid", GOLDEN, "--view", "new-batch-path", "--config", CONFIG),
+  ).toBe(0);
+  expect(out.join("\n")).toContain("Broadcast sender (added)");
+});
+
+test("mermaid rejects an invalid lens", async () => {
+  expect(await invoke("mermaid", GOLDEN, "--lens", "security", "--no-config")).toBe(2);
+  expect(err.join("\n")).toContain("architecture or data-flow");
+});
+
+test("mermaid rejects an unknown view", async () => {
+  expect(await invoke("mermaid", GOLDEN, "--view", "missing", "--no-config")).toBe(1);
+  expect(err.join("\n")).toContain("UNKNOWN_VIEW");
+});
+
+test("mermaid rejects a lens that disagrees with its view", async () => {
+  expect(
+    await invoke(
+      "mermaid",
+      GOLDEN,
+      "--view",
+      "send-pipeline-view",
+      "--lens",
+      "architecture",
+      "--no-config",
+    ),
+  ).toBe(2);
+  expect(err.join("\n")).toContain("uses the 'data-flow' lens");
+});
+
+test("mermaid reports corrections that remove the whole graph", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "pr-lens-mermaid-config-"));
+  const config = join(directory, "pr-lens.config.json");
+  await writeFile(
+    config,
+    JSON.stringify({ schemaVersion: "0.1.0", map: { exclude: ["**", "id:postmark"] } }),
+    "utf8",
+  );
+
+  expect(await invoke("mermaid", GOLDEN, "--config", config)).toBe(1);
+  expect(err.join("\n")).toContain("removed every node");
 });
 
 test("a valid document validates, and says what it holds", async () => {

--- a/packages/cli/test/version.test.ts
+++ b/packages/cli/test/version.test.ts
@@ -5,4 +5,5 @@ import { CLI_VERSION } from "../src/version.js";
 test("the version stamped on documents is the version that shipped", async () => {
   const manifest: unknown = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"));
   expect(manifest).toMatchObject({ version: CLI_VERSION });
+  expect(CLI_VERSION).toBe("0.3.0");
 });

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -1,6 +1,6 @@
 # @coldtea/pr-lens-renderer
 
-A schema-valid PR Lens graph document in, a self-contained animated SVG out. No network, no filesystem, no clock: the same document renders to the same bytes on any machine, which is what lets a diagram be addressed by the hash of itself.
+A schema-valid PR Lens graph document in, either a self-contained animated SVG or static Mermaid out. No network, no filesystem, no clock: the same document and projection render to the same bytes on any machine.
 
 MIT © Coldtea AI.
 
@@ -10,7 +10,7 @@ pnpm add @coldtea/pr-lens-renderer
 
 ```ts
 import { parseGraphDoc } from "@coldtea/pr-lens-schema";
-import { render, renderAll } from "@coldtea/pr-lens-renderer";
+import { render, renderAll, renderMermaid } from "@coldtea/pr-lens-renderer";
 
 const doc = parseGraphDoc(json);
 
@@ -19,6 +19,9 @@ const { svg, width, height } = render(doc, { lens: "architecture", theme: "dark"
 
 // Every drill-down section, in both themes, plus the manifest a comment is built from.
 const { assets, manifest } = renderAll(doc, { config });
+
+// One terminal-friendly projection from the same graph.
+const mermaid = renderMermaid(doc, { lens: "data-flow", view: "send-pipeline" });
 ```
 
 ## Two lenses
@@ -26,6 +29,10 @@ const { assets, manifest } = renderAll(doc, { config });
 `architecture` draws lanes of cards with the change written into them: a coloured outline and a badge per delta, removed elements ghosted and struck through, edges tinted by their own delta, one hero edge with a glow, and a travelling pulse on anything the document marked `animated`.
 
 `data-flow` draws a flow as a sequence: participant columns, lifelines, activation bars, return arrows, self-messages, and the architecture lens's travelling pulse on every step the document marks `animated`. Those steps share one cycle and take it in turn: one dot crossing one arrow at a time, in the order the steps happen, a repeated step taking consecutive turns. A turn is spent entirely on its crossing, so the next arrow lights as the last dot lands.
+
+## Mermaid for terminals
+
+`renderMermaid` projects an architecture lens as a Mermaid flowchart and a data-flow lens as a Mermaid sequence diagram. View scope, lane order, message order, corrections and delta labels come from the same graph used by the SVG renderer. Animation is intentionally absent. Graph labels are escaped before they enter Mermaid syntax, and stable aliases keep the result deterministic.
 
 ## Rendering for a GitHub comment
 
@@ -82,7 +89,7 @@ Labels, subtitles and titles come from a model. They are escaped for XML at the 
 
 ## Refusals
 
-`PrLensRenderError` carries a `code` a caller can switch on: `UNKNOWN_VIEW`, `LENS_NOT_DECLARED`, `NOTHING_TO_RENDER`, `NO_FLOW_IN_SCOPE`, `TOO_MANY_ASSETS`. A document that parsed is otherwise safe to render: the renderer trusts `@coldtea/pr-lens-schema` and never re-validates it.
+`PrLensRenderError` carries a `code` a caller can switch on: `UNKNOWN_VIEW`, `VIEW_LENS_MISMATCH`, `LENS_NOT_DECLARED`, `NOTHING_TO_RENDER`, `NO_FLOW_IN_SCOPE`, `TOO_MANY_ASSETS`. A document that parsed is otherwise safe to render: the renderer trusts `@coldtea/pr-lens-schema` and never re-validates it.
 
 `TOO_MANY_ASSETS` cannot be reached by a parsed document: the contract caps a view tree at `MAX_VIEWS`, which is `MAX_RENDER_ASSETS` divided by the two themes a `<picture>` pair needs. A hand-built one can reach it, because that cap lives in a refinement and a refinement does not survive into the inferred type. The check is a postcondition on what `renderAll` is about to produce rather than a re-reading of what came in, because how many pictures a render makes depends on how many themes the caller asked for, which no document knows.
 

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coldtea/pr-lens-renderer",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "The PR Lens renderer: a schema-valid graph document in, a self-contained animated SVG out.",
   "license": "MIT",
   "author": "Coldtea AI",

--- a/packages/renderer/src/errors.ts
+++ b/packages/renderer/src/errors.ts
@@ -5,6 +5,7 @@
  */
 export type RenderErrorCode =
   | "UNKNOWN_VIEW"
+  | "VIEW_LENS_MISMATCH"
   | "LENS_NOT_DECLARED"
   | "NOTHING_TO_RENDER"
   | "NO_FLOW_IN_SCOPE"

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -27,4 +27,6 @@ export {
 
 export { applyCorrections } from "./corrections.js";
 
+export { renderMermaid, type MermaidRenderOptions } from "./mermaid.js";
+
 export { findView, flattenViews, resolveScope, type ScopedGraph } from "./scope.js";

--- a/packages/renderer/src/mermaid.ts
+++ b/packages/renderer/src/mermaid.ts
@@ -1,0 +1,232 @@
+import type {
+  Config,
+  Delta,
+  FlowMessage,
+  GraphDoc,
+  GraphNode,
+  Lens,
+  View,
+  ViewScope,
+} from "@coldtea/pr-lens-schema";
+import { assertNever } from "@coldtea/pr-lens-schema";
+import { applyCorrections } from "./corrections.js";
+import { PrLensRenderError } from "./errors.js";
+import { findView, resolveScope, type ScopedGraph } from "./scope.js";
+
+export type MermaidRenderOptions = {
+  lens: Lens;
+  /** Id of the drill-down section to project. Omitted projects the whole document. */
+  view?: string;
+  /** The repository's corrections, applied before the projection is built. */
+  config?: Config;
+};
+
+const WHOLE_DOCUMENT: ViewScope = { kind: "all" };
+
+const requireView = (views: readonly View[], id: string): View => {
+  const view = findView(views, id);
+  if (view === undefined)
+    throw new PrLensRenderError("UNKNOWN_VIEW", `this document has no view '${id}'`);
+  return view;
+};
+
+/**
+ * Mermaid treats labels as syntax, so graph text has to be encoded before it
+ * enters quoted nodes, subgraphs, participants or edge labels.
+ */
+const LABEL_ESCAPES = new Map([
+  ["&", "&amp;"],
+  ['"', "&quot;"],
+  ["|", "&#124;"],
+  ["<", "&lt;"],
+  [">", "&gt;"],
+]);
+
+const escapeLabel = (value: string): string =>
+  value
+    .replace(/[&"|<>]/g, (character) => LABEL_ESCAPES.get(character) ?? "")
+    .replaceAll(/\r?\n/g, " ");
+
+const deltaText = (delta: Delta): string => {
+  switch (delta) {
+    case "added":
+      return " (added)";
+    case "modified":
+      return " (modified)";
+    case "removed":
+      return " (removed)";
+    case "unchanged":
+      return "";
+    default:
+      return assertNever(delta, "Unhandled delta");
+  }
+};
+
+const nodeLabel = (node: GraphNode): string =>
+  escapeLabel(`${node.label}${deltaText(node.delta)}${node.subtitle === undefined ? "" : ` / ${node.subtitle}`}`);
+
+const orderedLanes = (graph: ScopedGraph, doc: GraphDoc): ScopedGraph["lanes"] => {
+  const explicit = new Map(doc.layout?.laneOrder.map((id, index) => [id, index]) ?? []);
+  const sourceIndex = new Map(graph.lanes.map((lane, index) => [lane.id, index]));
+
+  return [...graph.lanes].sort((left, right) => {
+    const leftOrder = explicit.get(left.id) ?? left.order ?? sourceIndex.get(left.id) ?? 0;
+    const rightOrder = explicit.get(right.id) ?? right.order ?? sourceIndex.get(right.id) ?? 0;
+    return leftOrder - rightOrder;
+  });
+};
+
+const architectureDirection = (doc: GraphDoc): "LR" | "TD" => {
+  const direction = doc.layout?.direction ?? "right";
+  switch (direction) {
+    case "right":
+      return "LR";
+    case "down":
+      return "TD";
+    default:
+      return assertNever(direction, "Unhandled layout direction");
+  }
+};
+
+const architectureMermaid = (graph: ScopedGraph, doc: GraphDoc): string => {
+  if (graph.nodes.length === 0)
+    throw new PrLensRenderError("NOTHING_TO_RENDER", "no nodes are in scope for this view");
+
+  const aliases = new Map(graph.nodes.map((node, index) => [node.id, `n${index}`]));
+  const lines = [`flowchart ${architectureDirection(doc)}`];
+
+  for (const [laneIndex, lane] of orderedLanes(graph, doc).entries()) {
+    const subtitle = lane.subtitle === undefined ? "" : ` / ${lane.subtitle}`;
+    lines.push(`  subgraph lane${laneIndex}["${escapeLabel(`${lane.label}${subtitle}${deltaText(lane.delta ?? "unchanged")}`)}"]`);
+    for (const node of graph.nodes) {
+      if (node.lane !== lane.id) continue;
+      const alias = aliases.get(node.id);
+      if (alias === undefined)
+        throw new PrLensRenderError("NOTHING_TO_RENDER", `node '${node.id}' has no Mermaid alias`);
+      lines.push(`    ${alias}["${nodeLabel(node)}"]`);
+    }
+    lines.push("  end");
+  }
+
+  for (const edge of graph.edges) {
+    const from = aliases.get(edge.from);
+    const to = aliases.get(edge.to);
+    if (from === undefined || to === undefined)
+      throw new PrLensRenderError(
+        "NOTHING_TO_RENDER",
+        `edge '${edge.id}' points outside the selected Mermaid scope`,
+      );
+    const description = escapeLabel(`${edge.label ?? edge.kind}${deltaText(edge.delta)}`);
+    lines.push(`  ${from} -->|"${description}"| ${to}`);
+  }
+
+  return `${lines.join("\n")}\n`;
+};
+
+const messageArrow = (message: FlowMessage): string => {
+  switch (message.kind) {
+    case "sync":
+    case "self":
+      return "->>";
+    case "async":
+      return "-)";
+    case "return":
+      return "-->>";
+    default:
+      return assertNever(message.kind, "Unhandled message kind");
+  }
+};
+
+const dataFlowMermaid = (graph: ScopedGraph, doc: GraphDoc): string => {
+  if (graph.flows.length === 0)
+    throw new PrLensRenderError("NO_FLOW_IN_SCOPE", "the data-flow lens needs a flow to project");
+
+  const nodes = new Map(doc.nodes.map((node) => [node.id, node]));
+  const aliases = new Map<string, string>();
+  const labels = new Map<string, string>();
+
+  for (const flow of graph.flows)
+    for (const participant of flow.participants) {
+      if (aliases.has(participant.node)) continue;
+      const node = nodes.get(participant.node);
+      if (node === undefined)
+        throw new PrLensRenderError(
+          "NO_FLOW_IN_SCOPE",
+          `flow '${flow.id}' names unknown participant '${participant.node}'`,
+        );
+      aliases.set(participant.node, `p${aliases.size}`);
+      labels.set(participant.node, participant.label ?? node.label);
+    }
+
+  const lines = ["sequenceDiagram"];
+  for (const [nodeId, alias] of aliases) {
+    const label = labels.get(nodeId);
+    if (label === undefined)
+      throw new PrLensRenderError("NO_FLOW_IN_SCOPE", `participant '${nodeId}' has no label`);
+    lines.push(`  participant ${alias} as "${escapeLabel(label)}"`);
+  }
+
+  for (const flow of graph.flows) {
+    const firstParticipant = flow.participants[0];
+    const lastParticipant = flow.participants.at(-1);
+    const first = firstParticipant === undefined ? undefined : aliases.get(firstParticipant.node);
+    const last = lastParticipant === undefined ? undefined : aliases.get(lastParticipant.node);
+    if (first === undefined || last === undefined)
+      throw new PrLensRenderError(
+        "NO_FLOW_IN_SCOPE",
+        `flow '${flow.id}' has no complete participant range`,
+      );
+    lines.push(
+      `  Note over ${first},${last}: ${escapeLabel(`${flow.title}${deltaText(flow.delta)}`)}`,
+    );
+    for (const message of flow.messages) {
+      const from = aliases.get(message.from);
+      const to = aliases.get(message.to);
+      if (from === undefined || to === undefined)
+        throw new PrLensRenderError(
+          "NO_FLOW_IN_SCOPE",
+          `message '${message.id}' points outside its flow participants`,
+        );
+      const repeat = message.repeat === undefined ? "" : `, repeated ${message.repeat} times`;
+      lines.push(
+        `  ${from}${messageArrow(message)}${to}: ${escapeLabel(`${message.label}${deltaText(message.delta)}${repeat}`)}`,
+      );
+      if (message.note !== undefined)
+        lines.push(`  Note right of ${to}: ${escapeLabel(message.note)}`);
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+};
+
+/**
+ * Projects the same evidence graph used by the SVG renderer into terminal-
+ * friendly Mermaid. It contains no clock, file or random input, so identical
+ * documents and options always produce identical bytes.
+ */
+export const renderMermaid = (doc: GraphDoc, options: MermaidRenderOptions): string => {
+  const prepared = options.config === undefined ? doc : applyCorrections(doc, options.config.map);
+
+  if (!prepared.lenses.includes(options.lens))
+    throw new PrLensRenderError(
+      "LENS_NOT_DECLARED",
+      `this document does not declare the '${options.lens}' lens`,
+    );
+
+  const view = options.view === undefined ? undefined : requireView(prepared.views, options.view);
+  if (view !== undefined && view.lens !== options.lens)
+    throw new PrLensRenderError(
+      "VIEW_LENS_MISMATCH",
+      `view '${view.id}' uses the '${view.lens}' lens, not '${options.lens}'`,
+    );
+
+  const graph = resolveScope(prepared, view?.scope ?? WHOLE_DOCUMENT);
+  switch (options.lens) {
+    case "architecture":
+      return architectureMermaid(graph, prepared);
+    case "data-flow":
+      return dataFlowMermaid(graph, prepared);
+    default:
+      return assertNever(options.lens, "Unhandled Mermaid lens");
+  }
+};

--- a/packages/renderer/src/version.ts
+++ b/packages/renderer/src/version.ts
@@ -6,4 +6,4 @@
  */
 export const RENDERER_NAME = "@coldtea/pr-lens-renderer";
 
-export const RENDERER_VERSION = "0.1.2";
+export const RENDERER_VERSION = "0.2.0";

--- a/packages/renderer/test/mermaid.test.ts
+++ b/packages/renderer/test/mermaid.test.ts
@@ -1,0 +1,72 @@
+import { minimalGraph, postmarkRefactorGraph } from "@coldtea/pr-lens-schema/examples";
+import { describe, expect, it } from "vitest";
+import { renderMermaid } from "../src/index.js";
+
+describe("Mermaid projection", () => {
+  it("projects one architecture view without pulling in nodes outside its scope", () => {
+    const diagram = renderMermaid(postmarkRefactorGraph, {
+      lens: "architecture",
+      view: "new-batch-path",
+    });
+
+    expect(diagram).toMatch(/^flowchart LR\n/);
+    expect(diagram).toContain('subgraph lane0["Cloud Functions / Firebase"]');
+    expect(diagram).toContain("sendBroadcastBulk (added)");
+    expect(diagram).toContain("500 msgs/call (added)");
+    expect(diagram).not.toContain("processBroadcast");
+    expect(diagram).not.toContain("animate");
+  });
+
+  it("projects a data-flow view in message order", () => {
+    const diagram = renderMermaid(postmarkRefactorGraph, {
+      lens: "data-flow",
+      view: "send-pipeline-view",
+    });
+
+    expect(diagram).toMatch(/^sequenceDiagram\n/);
+    expect(diagram).toContain('participant p0 as "queue route"');
+    expect(diagram).toContain('participant p3 as "Postmark"');
+
+    const enqueue = diagram.indexOf("enqueue broadcast job (modified)");
+    const trigger = diagram.indexOf("onWrite trigger (added)");
+    const response = diagram.indexOf("suppressed addresses (added)");
+    expect(enqueue).toBeGreaterThan(-1);
+    expect(trigger).toBeGreaterThan(enqueue);
+    expect(response).toBeGreaterThan(trigger);
+    expect(diagram).toContain("p3-->>p2: suppressed addresses (added)");
+    expect(diagram).toContain("recipients; four for this 2,000-recipient broadcast.");
+  });
+
+  it("escapes labels before placing them in Mermaid syntax", () => {
+    const diagram = renderMermaid(
+      {
+        ...minimalGraph,
+        lanes: minimalGraph.lanes.map((lane) => ({ ...lane, label: 'API"] --> injected["' })),
+        nodes: minimalGraph.nodes.map((node) => ({
+          ...node,
+          label: 'health | "unsafe" <node>',
+        })),
+      },
+      { lens: "architecture" },
+    );
+
+    expect(diagram).not.toContain('"] --> injected["');
+    expect(diagram).not.toContain('"unsafe"');
+    expect(diagram).toContain("&quot;");
+    expect(diagram).toContain("&#124;");
+    expect(diagram).toContain("&lt;node&gt;");
+  });
+
+  it("is byte-for-byte deterministic", () => {
+    const first = renderMermaid(postmarkRefactorGraph, {
+      lens: "architecture",
+      view: "overview",
+    });
+    const second = renderMermaid(postmarkRefactorGraph, {
+      lens: "architecture",
+      view: "overview",
+    });
+
+    expect(second).toBe(first);
+  });
+});

--- a/packages/renderer/test/units.test.ts
+++ b/packages/renderer/test/units.test.ts
@@ -277,6 +277,7 @@ describe("the version in the manifest", () => {
     const pkg = parsed as { name: string; version: string };
     expect(RENDERER_NAME).toBe(pkg.name);
     expect(RENDERER_VERSION).toBe(pkg.version);
+    expect(RENDERER_VERSION).toBe("0.2.0");
   });
 });
 


### PR DESCRIPTION
Adds a deterministic static projection for readers who need PR Lens in a terminal.

## What changed

- add `renderMermaid` for architecture flowcharts and data-flow sequence diagrams
- add `pr-lens mermaid <graph.json>` with view/lens selection, config corrections, stdout, and file output
- escape graph labels at the Mermaid syntax boundary and keep stable aliases and source ordering
- keep static output free of animation while preserving view scope, deltas, participants, messages, and notes
- document the terminal workflow and bump the CLI to 0.3.0 and renderer to 0.2.0

## Verification

- `pnpm verify`
- renderer coverage: 85.47% statements and 85.58% lines for `mermaid.ts`
- CLI coverage: 87.93% statements and 92.45% lines for `commands/mermaid.ts`
- rendered the reference architecture and data-flow views with `mdmaid render-mermaid --backend beautiful-mermaid`
- `git diff --check`

## Boundaries

This adds a projection path only. It does not change graph extraction, SVG rendering, remote publishing, or PR comments.