### PR TITLE
Republish schema and renderer from a fresh build

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "node": ">=20.11"
   },
   "scripts": {
+    "prepublishOnly": "pnpm run build",
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coldtea/pr-lens-renderer",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The PR Lens renderer: a schema-valid graph document in, a self-contained animated SVG out.",
   "license": "MIT",
   "author": "Coldtea AI",
@@ -40,6 +40,7 @@
     "node": ">=20.11"
   },
   "scripts": {
+    "prepublishOnly": "pnpm run build",
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "vitest run",

--- a/packages/renderer/src/version.ts
+++ b/packages/renderer/src/version.ts
@@ -6,4 +6,4 @@
  */
 export const RENDERER_NAME = "@coldtea/pr-lens-renderer";
 
-export const RENDERER_VERSION = "0.2.0";
+export const RENDERER_VERSION = "0.2.1";

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coldtea/pr-lens-schema",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The PR Lens contract: versioned schemas for architecture / data-flow graph documents, baseline patches, config and render manifests.",
   "license": "MIT",
   "author": "Coldtea AI",
@@ -47,6 +47,7 @@
     "node": ">=20.11"
   },
   "scripts": {
+    "prepublishOnly": "pnpm run build",
     "build": "rm -rf dist && tsc -p tsconfig.build.json && pnpm run schema:emit",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "schema:emit": "tsx scripts/emit-artifacts.ts",


### PR DESCRIPTION
npm's 0.2.0 of the schema and renderer were published from a stale dist (no walkthrough, no atlas, contract 0.1.0). This bumps both to 0.2.1 and adds a prepublishOnly build to schema, renderer and CLI so publish can never ship an old dist again. Root verify green.