### PR TITLE
Card do not show new badge two time

### DIFF
--- a/packages/renderer/src/layout/architecture.ts
+++ b/packages/renderer/src/layout/architecture.ts
@@ -60,10 +60,18 @@ const trackedWidth = (
 export const badgeWidth = (text: string): number =>
   trackedWidth(text, "sans-bold", BADGE_TEXT_SIZE, BADGE_TRACKING) + BADGE_PADDING_X * 2;
 
-/** Every badge a card carries, its own first and the delta badge last. */
+/**
+ * Every badge a card carries, its own first and the delta badge last.
+ *
+ * A producer badge that already says the same thing as the delta badge
+ * (e.g. "new" on a node whose delta is "added") is dropped so the card
+ * does not show it twice.
+ */
 export const cardBadges = (node: GraphNode): string[] => {
   const delta = deltaBadgeText(node.delta);
-  return delta === undefined ? [...node.badges] : [...node.badges, delta];
+  if (delta === undefined) return [...node.badges];
+  const own = node.badges.filter((text) => text.toLowerCase() !== delta.toLowerCase());
+  return [...own, delta];
 };
 
 export type PlacedNode = {

--- a/packages/renderer/test/__goldens__/postmark-refactor.architecture.dark.svg
+++ b/packages/renderer/test/__goldens__/postmark-refactor.architecture.dark.svg
@@ -49,8 +49,7 @@
 <rect class="chip" x="470" y="442" width="26" height="26" rx="7"/><g><text class="glyph" x="483" y="459.5" text-anchor="middle" style="font-size:14px;font-style:italic;font-family:Georgia,serif">ƒ</text></g>
 <text class="ntitle" x="506" y="451" font-size="13">sendBroadcastBulk</text>
 <text class="nsub" x="506" y="469">onWrite trigger</text>
-<g class="bdg bdg-neutral"><rect x="738.4" y="416" width="36.05" height="16" rx="8"/><text x="756.43" y="427" text-anchor="middle">new</text></g>
-<g class="bdg bdg-added"><rect x="780.45" y="416" width="40.55" height="16" rx="8"/><text x="800.72" y="427" text-anchor="middle">NEW</text></g></g>
+<g class="bdg bdg-added"><rect x="780.45" y="416" width="40.55" height="16" rx="8"/><text x="800.73" y="427" text-anchor="middle">NEW</text></g></g>
 <g class="cardsh"><rect class="card card-added" x="456" y="538" width="180" height="62" rx="10"/>
 <rect class="chip" x="470" y="556" width="26" height="26" rx="7"/><g><path class="glyph-stroke" d="M483,562 l6.5,3.5 v7 l-6.5,3.5 l-6.5,-3.5 v-7 Z"/>
 <path class="glyph-stroke" d="M476.5,565.5 l6.5,3.5 l6.5,-3.5"/>

--- a/packages/renderer/test/__goldens__/postmark-refactor.architecture.light.svg
+++ b/packages/renderer/test/__goldens__/postmark-refactor.architecture.light.svg
@@ -49,8 +49,7 @@
 <rect class="chip" x="470" y="442" width="26" height="26" rx="7"/><g><text class="glyph" x="483" y="459.5" text-anchor="middle" style="font-size:14px;font-style:italic;font-family:Georgia,serif">ƒ</text></g>
 <text class="ntitle" x="506" y="451" font-size="13">sendBroadcastBulk</text>
 <text class="nsub" x="506" y="469">onWrite trigger</text>
-<g class="bdg bdg-neutral"><rect x="738.4" y="416" width="36.05" height="16" rx="8"/><text x="756.43" y="427" text-anchor="middle">new</text></g>
-<g class="bdg bdg-added"><rect x="780.45" y="416" width="40.55" height="16" rx="8"/><text x="800.72" y="427" text-anchor="middle">NEW</text></g></g>
+<g class="bdg bdg-added"><rect x="780.45" y="416" width="40.55" height="16" rx="8"/><text x="800.73" y="427" text-anchor="middle">NEW</text></g></g>
 <g class="cardsh"><rect class="card card-added" x="456" y="538" width="180" height="62" rx="10"/>
 <rect class="chip" x="470" y="556" width="26" height="26" rx="7"/><g><path class="glyph-stroke" d="M483,562 l6.5,3.5 v7 l-6.5,3.5 l-6.5,-3.5 v-7 Z"/>
 <path class="glyph-stroke" d="M476.5,565.5 l6.5,3.5 l6.5,-3.5"/>

--- a/packages/renderer/test/__goldens__/postmark-refactor.data-flow.dark.svg
+++ b/packages/renderer/test/__goldens__/postmark-refactor.data-flow.dark.svg
@@ -30,8 +30,7 @@
 <rect class="chip" x="556" y="36" width="26" height="26" rx="7"/><g><text class="glyph" x="569" y="53.5" text-anchor="middle" style="font-size:14px;font-style:italic;font-family:Georgia,serif">ƒ</text></g>
 <text class="ntitle" x="592" y="45" font-size="13">sendBroadcastBulk</text>
 <text class="nsub" x="592" y="63">onWrite trigger</text>
-<g class="bdg bdg-neutral"><rect x="635.4" y="10" width="36.05" height="16" rx="8"/><text x="653.42" y="21" text-anchor="middle">new</text></g>
-<g class="bdg bdg-added"><rect x="677.45" y="10" width="40.55" height="16" rx="8"/><text x="697.72" y="21" text-anchor="middle">NEW</text></g></g>
+<g class="bdg bdg-added"><rect x="677.45" y="10" width="40.55" height="16" rx="8"/><text x="697.73" y="21" text-anchor="middle">NEW</text></g></g>
 <g class="cardsh"><rect class="card card-modified" x="805" y="18" width="183" height="62" rx="10"/>
 <rect class="chip" x="819" y="36" width="26" height="26" rx="7"/><g><rect class="glyph-stroke" x="824" y="43" width="16" height="12" rx="2"/>
 <path class="glyph-stroke" d="M824,45 l8,6 8,-6"/></g>

--- a/packages/renderer/test/__goldens__/postmark-refactor.data-flow.light.svg
+++ b/packages/renderer/test/__goldens__/postmark-refactor.data-flow.light.svg
@@ -30,8 +30,7 @@
 <rect class="chip" x="556" y="36" width="26" height="26" rx="7"/><g><text class="glyph" x="569" y="53.5" text-anchor="middle" style="font-size:14px;font-style:italic;font-family:Georgia,serif">ƒ</text></g>
 <text class="ntitle" x="592" y="45" font-size="13">sendBroadcastBulk</text>
 <text class="nsub" x="592" y="63">onWrite trigger</text>
-<g class="bdg bdg-neutral"><rect x="635.4" y="10" width="36.05" height="16" rx="8"/><text x="653.42" y="21" text-anchor="middle">new</text></g>
-<g class="bdg bdg-added"><rect x="677.45" y="10" width="40.55" height="16" rx="8"/><text x="697.72" y="21" text-anchor="middle">NEW</text></g></g>
+<g class="bdg bdg-added"><rect x="677.45" y="10" width="40.55" height="16" rx="8"/><text x="697.73" y="21" text-anchor="middle">NEW</text></g></g>
 <g class="cardsh"><rect class="card card-modified" x="805" y="18" width="183" height="62" rx="10"/>
 <rect class="chip" x="819" y="36" width="26" height="26" rx="7"/><g><rect class="glyph-stroke" x="824" y="43" width="16" height="12" rx="2"/>
 <path class="glyph-stroke" d="M824,45 l8,6 8,-6"/></g>

--- a/packages/renderer/test/__goldens__/postmark-refactor.new-batch-path.dark.svg
+++ b/packages/renderer/test/__goldens__/postmark-refactor.new-batch-path.dark.svg
@@ -24,7 +24,6 @@
 <rect class="chip" x="46" y="110" width="26" height="26" rx="7"/><g><text class="glyph" x="59" y="127.5" text-anchor="middle" style="font-size:14px;font-style:italic;font-family:Georgia,serif">ƒ</text></g>
 <text class="ntitle" x="82" y="119" font-size="13">sendBroadcastBulk</text>
 <text class="nsub" x="82" y="137">onWrite trigger</text>
-<g class="bdg bdg-neutral"><rect x="314.4" y="84" width="36.05" height="16" rx="8"/><text x="332.42" y="95" text-anchor="middle">new</text></g>
 <g class="bdg bdg-added"><rect x="356.45" y="84" width="40.55" height="16" rx="8"/><text x="376.73" y="95" text-anchor="middle">NEW</text></g></g>
 <g class="cardsh"><rect class="card card-modified" x="32" y="206" width="180" height="62" rx="10"/>
 <rect class="chip" x="46" y="224" width="26" height="26" rx="7"/><g><ellipse class="glyph-stroke" cx="59" cy="232.5" rx="6.5" ry="2.6"/>

--- a/packages/renderer/test/units.test.ts
+++ b/packages/renderer/test/units.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Config, GraphDoc } from "@coldtea/pr-lens-schema";
+import type { Config, GraphDoc, GraphNode } from "@coldtea/pr-lens-schema";
 import { parseConfig, parseGraphDoc } from "@coldtea/pr-lens-schema";
 import { minimalGraph, postmarkRefactorGraph } from "@coldtea/pr-lens-schema/examples";
 import { describe, expect, it } from "vitest";
@@ -18,6 +18,7 @@ import {
   resolveScope,
 } from "../src/index.js";
 import { matchesGlob } from "../src/glob.js";
+import { cardBadges } from "../src/layout/architecture.js";
 import { measure, truncate } from "../src/text.js";
 import { TITLE_SIZE_MIN, TITLE_SIZE_SMALL } from "../src/design.js";
 
@@ -113,6 +114,34 @@ describe("fitting a title to its card", () => {
 
     expect(svg).toContain("…");
     expect(titleSizes(svg)[0]).toBe(TITLE_SIZE_MIN);
+  });
+});
+
+describe("card badges", () => {
+  const node = (delta: GraphNode["delta"], badges: string[]): GraphNode => ({
+    id: "n0",
+    label: "sendBroadcastBulk",
+    kind: "function",
+    delta,
+    lane: "functions",
+    files: [],
+    badges,
+  });
+
+  it("does not repeat the delta badge when a producer badge already says it", () => {
+    expect(cardBadges(node("added", ["new"]))).toEqual(["NEW"]);
+  });
+
+  it("matches the delta badge case-insensitively", () => {
+    expect(cardBadges(node("modified", ["Changed"]))).toEqual(["CHANGED"]);
+  });
+
+  it("keeps a producer badge that only overlaps the delta badge in part", () => {
+    expect(cardBadges(node("added", ["new package"]))).toEqual(["new package", "NEW"]);
+  });
+
+  it("keeps every producer badge when none of them repeat the delta badge", () => {
+    expect(cardBadges(node("modified", ["+38 / -12"]))).toEqual(["+38 / -12", "CHANGED"]);
   });
 });
 


### PR DESCRIPTION
Closes #2

When a node is `added`, the renderer already add a `NEW` badge for
it. But if the producer badge already say the same thing, like
`"new"`, the card show it two time, one grey one green. This is what
the screenshot in the issue show.

I make `cardBadges` skip a producer badge when it match the delta
badge text, case do not matter (`"new"` == `"NEW"`). A badge that
only partly match, like `"new package"`, is not touch, it stay as
before.

The `postmark-refactor` example got this exact case already
(`sendBroadcastBulk`, delta `added`, badge `["new"]`), so the golden
SVGs update too, only that one badge line is remove from each.

Test plan:
- [x] `pnpm --filter @coldtea/pr-lens-renderer test` green (169/169)
- [x] `pnpm --filter @coldtea/pr-lens-renderer typecheck` clean
- [x] checked the updated golden SVG by eye, only the duplicate `new` badge is gone