### PR TITLE
Colour the +N / -M badge like a real diff

### DIFF
--- a/packages/renderer/src/svg/architecture.ts
+++ b/packages/renderer/src/svg/architecture.ts
@@ -40,8 +40,22 @@ import { glyphGroup } from "./icons.js";
 import { lines, tag, textNode, wrap } from "./primitives.js";
 import { travellingPulses } from "./pulse.js";
 
-const badgeTone = (node: GraphNode, text: string): Tone =>
-  text === deltaBadgeText(node.delta) ? toneFor(node.delta) : "neutral";
+/** A line-count badge a producer writes itself, e.g. "+38 / -12". */
+const DIFF_STAT = /^\+(\d+)\s*\/\s*-(\d+)$/;
+
+const diffStatTone = (text: string): Tone | undefined => {
+  const stat = DIFF_STAT.exec(text);
+  if (stat === null) return undefined;
+  const added = Number(stat[1]);
+  const removed = Number(stat[2]);
+  if (added === removed) return undefined;
+  return added > removed ? "added" : "removed";
+};
+
+const badgeTone = (node: GraphNode, text: string): Tone => {
+  if (text === deltaBadgeText(node.delta)) return toneFor(node.delta);
+  return diffStatTone(text) ?? "neutral";
+};
 
 /** The badge row, laid left to right across the strip the layout reserved. */
 const paintBadges = (placed: PlacedNode): string => {

--- a/packages/renderer/test/__goldens__/postmark-refactor.architecture.dark.svg
+++ b/packages/renderer/test/__goldens__/postmark-refactor.architecture.dark.svg
@@ -37,7 +37,7 @@
 <g class="cardsh"><rect class="card card-modified" x="32" y="206" width="372" height="52" rx="10"/>
 <rect class="chip" x="46" y="219" width="26" height="26" rx="7"/><g><path class="glyph" d="M52,226 L66,232 L52,238 Z"/></g>
 <text class="ntitle" x="82" y="237" font-size="13">POST /api/broadcasts/queue</text>
-<g class="bdg bdg-neutral"><rect x="265.98" y="198" width="58.4" height="16" rx="8"/><text x="295.18" y="209" text-anchor="middle">+38 / -12</text></g>
+<g class="bdg bdg-added"><rect x="265.98" y="198" width="58.4" height="16" rx="8"/><text x="295.18" y="209" text-anchor="middle">+38 / -12</text></g>
 <g class="bdg bdg-modified"><rect x="330.38" y="198" width="66.62" height="16" rx="8"/><text x="363.69" y="209" text-anchor="middle">CHANGED</text></g></g>
 <g class="cardsh"><rect class="card card-modified" x="456" y="310" width="372" height="62" rx="10"/>
 <rect class="chip" x="470" y="328" width="26" height="26" rx="7"/><g><ellipse class="glyph-stroke" cx="483" cy="336.5" rx="6.5" ry="2.6"/>

--- a/packages/renderer/test/__goldens__/postmark-refactor.architecture.light.svg
+++ b/packages/renderer/test/__goldens__/postmark-refactor.architecture.light.svg
@@ -37,7 +37,7 @@
 <g class="cardsh"><rect class="card card-modified" x="32" y="206" width="372" height="52" rx="10"/>
 <rect class="chip" x="46" y="219" width="26" height="26" rx="7"/><g><path class="glyph" d="M52,226 L66,232 L52,238 Z"/></g>
 <text class="ntitle" x="82" y="237" font-size="13">POST /api/broadcasts/queue</text>
-<g class="bdg bdg-neutral"><rect x="265.98" y="198" width="58.4" height="16" rx="8"/><text x="295.18" y="209" text-anchor="middle">+38 / -12</text></g>
+<g class="bdg bdg-added"><rect x="265.98" y="198" width="58.4" height="16" rx="8"/><text x="295.18" y="209" text-anchor="middle">+38 / -12</text></g>
 <g class="bdg bdg-modified"><rect x="330.38" y="198" width="66.62" height="16" rx="8"/><text x="363.69" y="209" text-anchor="middle">CHANGED</text></g></g>
 <g class="cardsh"><rect class="card card-modified" x="456" y="310" width="372" height="62" rx="10"/>
 <rect class="chip" x="470" y="328" width="26" height="26" rx="7"/><g><ellipse class="glyph-stroke" cx="483" cy="336.5" rx="6.5" ry="2.6"/>

--- a/packages/renderer/test/__goldens__/postmark-refactor.data-flow.dark.svg
+++ b/packages/renderer/test/__goldens__/postmark-refactor.data-flow.dark.svg
@@ -18,7 +18,7 @@
 <g><g class="cardsh"><rect class="card card-modified" x="16" y="18" width="183" height="52" rx="10"/>
 <rect class="chip" x="30" y="31" width="26" height="26" rx="7"/><g><path class="glyph" d="M36,38 L50,44 L36,50 Z"/></g>
 <text class="ntitle" x="66" y="49" font-size="13">queue route</text>
-<g class="bdg bdg-neutral"><rect x="60.98" y="10" width="58.4" height="16" rx="8"/><text x="90.18" y="21" text-anchor="middle">+38 / -12</text></g>
+<g class="bdg bdg-added"><rect x="60.98" y="10" width="58.4" height="16" rx="8"/><text x="90.18" y="21" text-anchor="middle">+38 / -12</text></g>
 <g class="bdg bdg-modified"><rect x="125.38" y="10" width="66.62" height="16" rx="8"/><text x="158.69" y="21" text-anchor="middle">CHANGED</text></g></g>
 <g class="cardsh"><rect class="card card-modified" x="279" y="18" width="183" height="62" rx="10"/>
 <rect class="chip" x="293" y="36" width="26" height="26" rx="7"/><g><ellipse class="glyph-stroke" cx="306" cy="44.5" rx="6.5" ry="2.6"/>

--- a/packages/renderer/test/__goldens__/postmark-refactor.data-flow.light.svg
+++ b/packages/renderer/test/__goldens__/postmark-refactor.data-flow.light.svg
@@ -18,7 +18,7 @@
 <g><g class="cardsh"><rect class="card card-modified" x="16" y="18" width="183" height="52" rx="10"/>
 <rect class="chip" x="30" y="31" width="26" height="26" rx="7"/><g><path class="glyph" d="M36,38 L50,44 L36,50 Z"/></g>
 <text class="ntitle" x="66" y="49" font-size="13">queue route</text>
-<g class="bdg bdg-neutral"><rect x="60.98" y="10" width="58.4" height="16" rx="8"/><text x="90.18" y="21" text-anchor="middle">+38 / -12</text></g>
+<g class="bdg bdg-added"><rect x="60.98" y="10" width="58.4" height="16" rx="8"/><text x="90.18" y="21" text-anchor="middle">+38 / -12</text></g>
 <g class="bdg bdg-modified"><rect x="125.38" y="10" width="66.62" height="16" rx="8"/><text x="158.69" y="21" text-anchor="middle">CHANGED</text></g></g>
 <g class="cardsh"><rect class="card card-modified" x="279" y="18" width="183" height="62" rx="10"/>
 <rect class="chip" x="293" y="36" width="26" height="26" rx="7"/><g><ellipse class="glyph-stroke" cx="306" cy="44.5" rx="6.5" ry="2.6"/>

--- a/packages/renderer/test/units.test.ts
+++ b/packages/renderer/test/units.test.ts
@@ -64,6 +64,50 @@ describe("truncation", () => {
   });
 });
 
+describe("diff-stat badge colour", () => {
+  const oneNode = (delta: GraphDoc["nodes"][number]["delta"], badge: string): GraphDoc =>
+    parseGraphDoc({
+      ...minimalGraph,
+      nodes: [
+        {
+          id: "n0",
+          label: "health-route",
+          kind: "route",
+          delta,
+          lane: "api",
+          files: [],
+          badges: [badge],
+        },
+      ],
+    });
+
+  /** The tone class the first badge matching `text` was painted in. */
+  const badgeTone = (svg: string, text: string): string | undefined => {
+    const escaped = text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`class="bdg bdg-(\\w+)"[\\s\\S]*?>${escaped}<`).exec(svg)?.[1];
+  };
+
+  it("tones a diff-stat badge added when it added more lines than it removed", () => {
+    const { svg } = render(oneNode("modified", "+80 / -3"), { lens: "architecture", theme: "dark" });
+    expect(badgeTone(svg, "+80 / -3")).toBe("added");
+  });
+
+  it("tones a diff-stat badge removed when it removed more lines than it added", () => {
+    const { svg } = render(oneNode("modified", "+3 / -80"), { lens: "architecture", theme: "dark" });
+    expect(badgeTone(svg, "+3 / -80")).toBe("removed");
+  });
+
+  it("leaves a diff-stat badge neutral when it added and removed the same", () => {
+    const { svg } = render(oneNode("modified", "+5 / -5"), { lens: "architecture", theme: "dark" });
+    expect(badgeTone(svg, "+5 / -5")).toBe("neutral");
+  });
+
+  it("leaves a badge that is not a diff stat neutral", () => {
+    const { svg } = render(oneNode("modified", "wip"), { lens: "architecture", theme: "dark" });
+    expect(badgeTone(svg, "wip")).toBe("neutral");
+  });
+});
+
 describe("fitting a title to its card", () => {
   const pairedLane = (...labels: readonly string[]): GraphDoc =>
     parseGraphDoc({


### PR DESCRIPTION
Closes #3

The issue say the diff-stat badge (`+38 / -12` style) is always
grey, even when it come from a real diff. It ask for it to be diff
like: green when it add more, red when it remove more.

I add a small parse for this badge shape (`+N / -M`) in `badgeTone`.
When it match, the badge get the `added` tone if it add more line
than remove, `removed` tone if the other way, and stay `neutral`
when the number are equal. A badge that is not this shape (a plain
word badge like `"wip"`) is not touch.

The `postmark-refactor` example has a `+38 / -12` badge on its
`queue-route` node, so the golden SVGs update, only the badge class
change from `bdg-neutral` to `bdg-added`.

Test plan:
- [x] `pnpm --filter @coldtea/pr-lens-renderer test` green (169/169)
- [x] `pnpm --filter @coldtea/pr-lens-renderer typecheck` clean
- [x] checked the updated golden SVG, `+38 / -12` now render in the added colour