### PR TITLE
🐛 fix: measures full-width glyphs at a full em

### DIFF
--- a/packages/renderer/src/text.ts
+++ b/packages/renderer/src/text.ts
@@ -28,8 +28,32 @@ const SANS_ADVANCE: Readonly<Record<string, number>> = {
   y: 500, z: 500, "{": 334, "|": 260, "}": 334, "~": 584,
 };
 
-/** What a character outside the table is assumed to cost, in the same units. */
+/** What a narrow character outside the table is assumed to cost, in the same units. */
 const FALLBACK_ADVANCE = 600;
+
+/**
+ * East Asian Wide and Fullwidth glyphs occupy a full em. Measuring them at
+ * the narrow fallback puts every CJK label about 38% short of its real width,
+ * which is enough for an edge label's plate to stop covering its own text.
+ */
+const isWide = (character: string): boolean => {
+  const point = character.codePointAt(0) ?? 0;
+  return (
+    (point >= 0x1100 && point <= 0x115f) ||
+    (point >= 0x2e80 && point <= 0xa4cf) ||
+    (point >= 0xac00 && point <= 0xd7a3) ||
+    (point >= 0xf900 && point <= 0xfaff) ||
+    (point >= 0xfe30 && point <= 0xfe6f) ||
+    (point >= 0xff00 && point <= 0xff60) ||
+    (point >= 0xffe0 && point <= 0xffe6) ||
+    (point >= 0x20000 && point <= 0x3fffd)
+  );
+};
+
+const FULL_WIDTH_ADVANCE = 1000;
+
+const fallbackAdvance = (character: string): number =>
+  isWide(character) ? FULL_WIDTH_ADVANCE : FALLBACK_ADVANCE;
 
 /**
  * The bold face of the same family runs a little wider at every weight step.
@@ -43,9 +67,9 @@ const MONO_ADVANCE = 600;
 const advanceFor = (face: Face, character: string): number => {
   switch (face) {
     case "sans":
-      return SANS_ADVANCE[character] ?? FALLBACK_ADVANCE;
+      return SANS_ADVANCE[character] ?? fallbackAdvance(character);
     case "sans-bold":
-      return (SANS_ADVANCE[character] ?? FALLBACK_ADVANCE) * BOLD_WIDENING;
+      return (SANS_ADVANCE[character] ?? fallbackAdvance(character)) * BOLD_WIDENING;
     case "mono":
       return MONO_ADVANCE;
     default:

--- a/packages/renderer/test/__goldens__/cjk.architecture.dark.svg
+++ b/packages/renderer/test/__goldens__/cjk.architecture.dark.svg
@@ -1,0 +1,44 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 522" width="860" height="522" role="img" aria-label="알림 발송을 대기열로 옮기기">
+<title>알림 발송을 대기열로 옮기기</title>
+<desc>발송 API가 게이트웨이를 직접 부르던 것을 대기열에 넣는 것으로 바꿉니다.</desc>
+<style>text{font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif}.lanebox{fill:rgba(110,118,129,.07)}.lanelabel{font-size:10px;font-weight:700;letter-spacing:.12em;fill:#9198a1}.card{fill:#1c2128;stroke:#3d444d;stroke-width:1}.card-added{stroke:#3fb950;stroke-opacity:.55}.card-modified{stroke:#d29922;stroke-opacity:.5}.ghost{opacity:.55}.ghost .card{stroke:#f85149;stroke-dasharray:4 3;stroke-opacity:.6}.context{opacity:.82}.ntitle{font-weight:600;fill:#e6edf3}.strike{text-decoration:line-through}.nsub{font-size:9.5px;fill:#9198a1;font-family:ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace}.chip{fill:rgba(110,118,129,.18)}.glyph{fill:#9198a1}.glyph-stroke{stroke:#9198a1;stroke-width:1.4;fill:none}.bdg text{font-size:8.5px;font-weight:700;letter-spacing:.06em}.bdg rect{stroke-width:1}.bdg-added rect{fill:rgba(46,160,67,.15);stroke:rgba(63,185,80,.4)}.bdg-added text{fill:#3fb950}.bdg-modified rect{fill:rgba(187,128,9,.15);stroke:rgba(210,153,34,.4)}.bdg-modified text{fill:#d29922}.bdg-removed rect{fill:rgba(248,81,73,.12);stroke:rgba(248,81,73,.4)}.bdg-removed text{fill:#f85149}.bdg-neutral rect{fill:rgba(110,118,129,.18);stroke:#3d444d}.bdg-neutral text{fill:#9198a1}.edge{fill:none;stroke-width:1.5}.edge-added{stroke:#3fb950}.edge-modified{stroke:#d29922}.edge-removed{stroke:#f85149;stroke-dasharray:5 4;opacity:.7}.edge-neutral{stroke:#6e7681}.hero{stroke-width:2.25}.faded{opacity:.45}.glow{fill:none;stroke-width:7;opacity:.14}.msg-self{font-size:11px;fill:#e6edf3}.lpill{fill:#0d1117;stroke:#21262d;stroke-width:1}.ltext{font-size:9.5px;font-weight:600;fill:#9198a1}.ltext-added{fill:#3fb950}.ltext-modified{fill:#d29922}.ltext-removed{fill:#f85149}.cardsh{filter:drop-shadow(0 1px 2px rgba(0,0,0,.28))}.lifeline{stroke:#30363d;stroke-width:1;stroke-dasharray:3 4}.actbar{fill:rgba(46,160,67,.15);stroke:rgba(63,185,80,.4)}.msg{fill:none;stroke-width:1.5}.msg-return{stroke-dasharray:4 3;opacity:.8}.msg-strong{stroke-width:2.25}</style>
+<defs><pattern id="dots" width="18" height="18" patternUnits="userSpaceOnUse"><circle cx="1.5" cy="1.5" r="1" fill="rgba(110,118,129,.22)"/></pattern><marker id="mk-added" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3fb950"/></marker><marker id="mko-added" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M2,1 L10,5 L2,9" fill="none" stroke="#3fb950" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker><marker id="mk-modified" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#d29922"/></marker><marker id="mko-modified" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M2,1 L10,5 L2,9" fill="none" stroke="#d29922" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker><marker id="mk-removed" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#f85149"/></marker><marker id="mko-removed" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M2,1 L10,5 L2,9" fill="none" stroke="#f85149" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker><marker id="mk-neutral" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#6e7681"/></marker><marker id="mko-neutral" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M2,1 L10,5 L2,9" fill="none" stroke="#6e7681" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker></defs>
+<rect x="0" y="0" width="860" height="522" rx="12" fill="#0d1117"/>
+<rect x="0" y="0" width="860" height="522" rx="12" fill="url(#dots)"/>
+<g><rect class="lanebox" x="16" y="44" width="404" height="462" rx="12"/>
+<text class="lanelabel" x="32" y="68">앱 · アプリ</text>
+<rect class="lanebox" x="440" y="44" width="404" height="462" rx="12"/>
+<text class="lanelabel" x="456" y="68">워커 · WORKERS</text></g>
+<g><path class="glow" stroke="#3fb950" d="M404,123 L417,123 C424.18,123 430,128.82 430,136 L430,224 C430,231.18 435.82,237 443,237 L456,237"/>
+<path class="edge edge-added hero" d="M404,123 L417,123 C424.18,123 430,128.82 430,136 L430,224 C430,231.18 435.82,237 443,237 L456,237" marker-end="url(#mk-added)"/>
+<circle r="3" fill="#3fb950"><animateMotion dur="2.1s" repeatCount="indefinite" path="M404,123 L417,123 C424.18,123 430,128.82 430,136 L430,224 C430,231.18 435.82,237 443,237 L456,237"/></circle>
+<circle r="3" fill="#3fb950"><animateMotion dur="2.1s" begin="-1.4s" repeatCount="indefinite" path="M404,123 L417,123 C424.18,123 430,128.82 430,136 L430,224 C430,231.18 435.82,237 443,237 L456,237"/></circle>
+<circle r="3" fill="#3fb950"><animateMotion dur="2.1s" begin="-0.7s" repeatCount="indefinite" path="M404,123 L417,123 C424.18,123 430,128.82 430,136 L430,224 C430,231.18 435.82,237 443,237 L456,237"/></circle>
+<path class="edge edge-added" d="M642,268 L642,320" marker-end="url(#mk-added)"/>
+<path class="edge edge-neutral context" d="M642,382 L642,434" marker-end="url(#mk-neutral)"/></g>
+<g><g class="cardsh"><rect class="card card-modified" x="32" y="92" width="372" height="62" rx="10"/>
+<rect class="chip" x="46" y="110" width="26" height="26" rx="7"/><g><path class="glyph" d="M52,117 L66,123 L52,129 Z"/></g>
+<text class="ntitle" x="82" y="119" font-size="13">알림 발송 API</text>
+<text class="nsub" x="82" y="137">createNotification</text>
+<g class="bdg bdg-modified"><rect x="330.38" y="84" width="66.62" height="16" rx="8"/><text x="363.69" y="95" text-anchor="middle">CHANGED</text></g></g>
+<g class="cardsh"><rect class="card card-added" x="456" y="206" width="372" height="62" rx="10"/>
+<rect class="chip" x="470" y="224" width="26" height="26" rx="7"/><g><path class="glyph-stroke" d="M476.5,232.5 h13"/>
+<path class="glyph-stroke" d="M476.5,237 h13"/>
+<path class="glyph-stroke" d="M476.5,241.5 h13"/></g>
+<text class="ntitle" x="506" y="233" font-size="13">通知キュー</text>
+<text class="nsub" x="506" y="251">notification-jobs</text>
+<g class="bdg bdg-added"><rect x="780.45" y="198" width="40.55" height="16" rx="8"/><text x="800.73" y="209" text-anchor="middle">NEW</text></g></g>
+<g class="cardsh"><rect class="card card-added" x="456" y="320" width="372" height="62" rx="10"/>
+<rect class="chip" x="470" y="338" width="26" height="26" rx="7"/><g><ellipse class="glyph-stroke" cx="483" cy="346.5" rx="6.5" ry="2.6"/>
+<path class="glyph-stroke" d="M476.5,346.5 v9 a6.5,2.6 0 0 0 13 0 v-9"/></g>
+<text class="ntitle" x="506" y="347" font-size="13">发送记录</text>
+<text class="nsub" x="506" y="365">delivery_log</text>
+<g class="bdg bdg-added"><rect x="780.45" y="312" width="40.55" height="16" rx="8"/><text x="800.73" y="323" text-anchor="middle">NEW</text></g></g>
+<g class="cardsh context"><rect class="card" x="456" y="434" width="372" height="52" rx="10"/>
+<rect class="chip" x="470" y="447" width="26" height="26" rx="7"/><g><rect class="glyph-stroke" x="475" y="454" width="16" height="12" rx="2"/>
+<path class="glyph-stroke" d="M475,456 l8,6 8,-6"/></g>
+<text class="ntitle" x="506" y="465" font-size="13">delivery gateway</text></g></g>
+<g><g><rect class="lpill" x="340.88" y="172.5" width="178.25" height="15" rx="7.5"/><text class="ltext ltext-added" x="430" y="183.5" text-anchor="middle">발송 작업 하나를 대기열에 넣습니다</text></g>
+<g><rect class="lpill" x="568.54" y="286.5" width="146.91" height="15" rx="7.5"/><text class="ltext ltext-added" x="642" y="297.5" text-anchor="middle">送信記録を一件書き込みます</text></g>
+<g><rect class="lpill" x="562.07" y="400.5" width="159.86" height="15" rx="7.5"/><text class="ltext" x="642" y="411.5" text-anchor="middle">hands the record to the gateway</text></g></g>
+</svg>

--- a/packages/renderer/test/__goldens__/cjk.data-flow.dark.svg
+++ b/packages/renderer/test/__goldens__/cjk.data-flow.dark.svg
@@ -1,0 +1,52 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 964 299" width="964" height="299" role="img" aria-label="알림 발송을 대기열로 옮기기">
+<title>알림 발송을 대기열로 옮기기</title>
+<desc>발송 API가 게이트웨이를 직접 부르던 것을 대기열에 넣는 것으로 바꿉니다.</desc>
+<style>text{font-family:-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif}.lanebox{fill:rgba(110,118,129,.07)}.lanelabel{font-size:10px;font-weight:700;letter-spacing:.12em;fill:#9198a1}.card{fill:#1c2128;stroke:#3d444d;stroke-width:1}.card-added{stroke:#3fb950;stroke-opacity:.55}.card-modified{stroke:#d29922;stroke-opacity:.5}.ghost{opacity:.55}.ghost .card{stroke:#f85149;stroke-dasharray:4 3;stroke-opacity:.6}.context{opacity:.82}.ntitle{font-weight:600;fill:#e6edf3}.strike{text-decoration:line-through}.nsub{font-size:9.5px;fill:#9198a1;font-family:ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace}.chip{fill:rgba(110,118,129,.18)}.glyph{fill:#9198a1}.glyph-stroke{stroke:#9198a1;stroke-width:1.4;fill:none}.bdg text{font-size:8.5px;font-weight:700;letter-spacing:.06em}.bdg rect{stroke-width:1}.bdg-added rect{fill:rgba(46,160,67,.15);stroke:rgba(63,185,80,.4)}.bdg-added text{fill:#3fb950}.bdg-modified rect{fill:rgba(187,128,9,.15);stroke:rgba(210,153,34,.4)}.bdg-modified text{fill:#d29922}.bdg-removed rect{fill:rgba(248,81,73,.12);stroke:rgba(248,81,73,.4)}.bdg-removed text{fill:#f85149}.bdg-neutral rect{fill:rgba(110,118,129,.18);stroke:#3d444d}.bdg-neutral text{fill:#9198a1}.edge{fill:none;stroke-width:1.5}.edge-added{stroke:#3fb950}.edge-modified{stroke:#d29922}.edge-removed{stroke:#f85149;stroke-dasharray:5 4;opacity:.7}.edge-neutral{stroke:#6e7681}.hero{stroke-width:2.25}.faded{opacity:.45}.glow{fill:none;stroke-width:7;opacity:.14}.msg-self{font-size:11px;fill:#e6edf3}.lpill{fill:#0d1117;stroke:#21262d;stroke-width:1}.ltext{font-size:9.5px;font-weight:600;fill:#9198a1}.ltext-added{fill:#3fb950}.ltext-modified{fill:#d29922}.ltext-removed{fill:#f85149}.cardsh{filter:drop-shadow(0 1px 2px rgba(0,0,0,.28))}.lifeline{stroke:#30363d;stroke-width:1;stroke-dasharray:3 4}.actbar{fill:rgba(46,160,67,.15);stroke:rgba(63,185,80,.4)}.msg{fill:none;stroke-width:1.5}.msg-return{stroke-dasharray:4 3;opacity:.8}.msg-strong{stroke-width:2.25}</style>
+<defs><pattern id="dots" width="18" height="18" patternUnits="userSpaceOnUse"><circle cx="1.5" cy="1.5" r="1" fill="rgba(110,118,129,.22)"/></pattern><marker id="mk-added" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#3fb950"/></marker><marker id="mko-added" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M2,1 L10,5 L2,9" fill="none" stroke="#3fb950" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker><marker id="mk-modified" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#d29922"/></marker><marker id="mko-modified" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M2,1 L10,5 L2,9" fill="none" stroke="#d29922" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker><marker id="mk-removed" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#f85149"/></marker><marker id="mko-removed" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M2,1 L10,5 L2,9" fill="none" stroke="#f85149" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker><marker id="mk-neutral" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#6e7681"/></marker><marker id="mko-neutral" viewBox="0 0 10 10" refX="10" refY="5" markerWidth="6.5" markerHeight="6.5" orient="auto-start-reverse"><path d="M2,1 L10,5 L2,9" fill="none" stroke="#6e7681" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></marker></defs>
+<rect x="0" y="0" width="964" height="299" rx="12" fill="#0d1117"/>
+<rect x="0" y="0" width="964" height="299" rx="12" fill="url(#dots)"/>
+<g transform="translate(12,10)"><g><rect class="lanebox" x="4" y="6" width="191" height="267" rx="12"/>
+<rect class="lanebox" x="251" y="6" width="191" height="267" rx="12"/>
+<rect class="lanebox" x="498" y="6" width="191" height="267" rx="12"/>
+<rect class="lanebox" x="745" y="6" width="191" height="267" rx="12"/></g>
+<g><line class="lifeline" x1="99.5" y1="82" x2="99.5" y2="261"/>
+<line class="lifeline" x1="346.5" y1="82" x2="346.5" y2="261"/>
+<line class="lifeline" x1="593.5" y1="82" x2="593.5" y2="261"/>
+<rect class="actbar" x="587.5" y="161" width="12" height="88.67" rx="4"/>
+<line class="lifeline" x1="840.5" y1="82" x2="840.5" y2="261"/>
+<rect class="actbar" x="834.5" y="199" width="12" height="38" rx="4"/></g>
+<g><g class="cardsh"><rect class="card card-modified" x="16" y="18" width="167" height="62" rx="10"/>
+<rect class="chip" x="30" y="36" width="26" height="26" rx="7"/><g><path class="glyph" d="M36,43 L50,49 L36,55 Z"/></g>
+<text class="ntitle" x="66" y="45" font-size="13">알림 발송 API</text>
+<text class="nsub" x="66" y="63">createNotification</text>
+<g class="bdg bdg-modified"><rect x="109.38" y="10" width="66.62" height="16" rx="8"/><text x="142.69" y="21" text-anchor="middle">CHANGED</text></g></g>
+<g class="cardsh"><rect class="card card-added" x="263" y="18" width="167" height="62" rx="10"/>
+<rect class="chip" x="277" y="36" width="26" height="26" rx="7"/><g><path class="glyph-stroke" d="M283.5,44.5 h13"/>
+<path class="glyph-stroke" d="M283.5,49 h13"/>
+<path class="glyph-stroke" d="M283.5,53.5 h13"/></g>
+<text class="ntitle" x="313" y="45" font-size="13">通知キュー</text>
+<text class="nsub" x="313" y="63">notification-jobs</text>
+<g class="bdg bdg-added"><rect x="382.45" y="10" width="40.55" height="16" rx="8"/><text x="402.73" y="21" text-anchor="middle">NEW</text></g></g>
+<g class="cardsh"><rect class="card card-added" x="510" y="18" width="167" height="62" rx="10"/>
+<rect class="chip" x="524" y="36" width="26" height="26" rx="7"/><g><ellipse class="glyph-stroke" cx="537" cy="44.5" rx="6.5" ry="2.6"/>
+<path class="glyph-stroke" d="M530.5,44.5 v9 a6.5,2.6 0 0 0 13 0 v-9"/></g>
+<text class="ntitle" x="560" y="45" font-size="13">发送记录</text>
+<text class="nsub" x="560" y="63">delivery_log</text>
+<g class="bdg bdg-added"><rect x="629.45" y="10" width="40.55" height="16" rx="8"/><text x="649.73" y="21" text-anchor="middle">NEW</text></g></g>
+<g class="cardsh context"><rect class="card" x="757" y="18" width="167" height="52" rx="10"/>
+<rect class="chip" x="771" y="31" width="26" height="26" rx="7"/><g><rect class="glyph-stroke" x="776" y="38" width="16" height="12" rx="2"/>
+<path class="glyph-stroke" d="M776,40 l8,6 8,-6"/></g>
+<text class="ntitle" x="807" y="49" font-size="13">delivery gateway</text></g></g>
+<g><path class="msg edge-added msg-strong" d="M99.5,123 L341.5,123" marker-end="url(#mko-added)"/>
+<circle r="2.6" fill="#3fb950" opacity="0"><animateMotion dur="5.6s" repeatCount="indefinite" keyPoints="0;0;1;1" keyTimes="0;0;0.25;1" calcMode="linear" path="M99.5,123 L341.5,123"/><animate attributeName="opacity" dur="5.6s" repeatCount="indefinite" values="0;0;1;1;0;0" keyTimes="0;0;0.02;0.23;0.25;1"/></circle>
+<path class="msg edge-added msg-strong" d="M346.5,161 L582.5,161" marker-end="url(#mk-added)"/>
+<circle r="2.6" fill="#3fb950" opacity="0"><animateMotion dur="5.6s" repeatCount="indefinite" keyPoints="0;0;1;1" keyTimes="0;0.25;0.5;1" calcMode="linear" path="M346.5,161 L582.5,161"/><animate attributeName="opacity" dur="5.6s" repeatCount="indefinite" values="0;0;1;1;0;0" keyTimes="0;0.25;0.27;0.48;0.5;1"/></circle>
+<path class="msg edge-neutral" d="M599.5,199 L829.5,199" marker-end="url(#mk-neutral)"/>
+<circle r="2.6" fill="#6e7681" opacity="0"><animateMotion dur="5.6s" repeatCount="indefinite" keyPoints="0;0;1;1" keyTimes="0;0.5;0.75;1" calcMode="linear" path="M599.5,199 L829.5,199"/><animate attributeName="opacity" dur="5.6s" repeatCount="indefinite" values="0;0;1;1;0;0" keyTimes="0;0.5;0.52;0.73;0.75;1"/></circle>
+<path class="msg edge-neutral msg-return" d="M834.5,237 L604.5,237" marker-end="url(#mk-neutral)"/>
+<circle r="2.6" fill="#6e7681" opacity="0"><animateMotion dur="5.6s" repeatCount="indefinite" keyPoints="0;0;1;1" keyTimes="0;0.75;1;1" calcMode="linear" path="M834.5,237 L604.5,237"/><animate attributeName="opacity" dur="5.6s" repeatCount="indefinite" values="0;0;1;1;0;0" keyTimes="0;0.75;0.77;0.98;1;1"/></circle></g>
+<g><g><rect class="lpill" x="131.38" y="115.5" width="178.25" height="15" rx="7.5"/><text class="ltext ltext-added" x="220.5" y="126.5" text-anchor="middle">발송 작업 하나를 대기열에 넣습니다</text></g>
+<g><rect class="lpill" x="391.05" y="153.5" width="146.91" height="15" rx="7.5"/><text class="ltext ltext-added" x="464.5" y="164.5" text-anchor="middle">送信記録を一件書き込みます</text></g>
+<g><rect class="lpill" x="656.15" y="191.5" width="116.7" height="15" rx="7.5"/><text class="ltext" x="714.5" y="202.5" text-anchor="middle">把这条记录发送给网关</text></g>
+<g><rect class="lpill" x="652.18" y="229.5" width="134.63" height="15" rx="7.5"/><text class="ltext" x="719.5" y="240.5" text-anchor="middle">delivery result comes back</text></g></g></g>
+</svg>

--- a/packages/renderer/test/cjk.ts
+++ b/packages/renderer/test/cjk.ts
@@ -1,0 +1,139 @@
+import type { GraphDoc } from "@coldtea/pr-lens-schema";
+import { parseGraphDoc, SCHEMA_VERSION } from "@coldtea/pr-lens-schema";
+
+/**
+ * Labels in the three scripts whose glyphs take a full em: Hangul, Japanese
+ * kana, and Han. Latin labels sit beside them so a golden that only moved
+ * because the whole layout shifted is told apart from one where the wide
+ * measurements changed.
+ *
+ * The edge and message labels are long on purpose. A label's plate is drawn
+ * to its measured width, so a script measured at the narrow fallback is
+ * covered by a plate too small for it, and the line beneath runs through the
+ * text. That is what this golden holds still.
+ */
+export const cjkGraph: GraphDoc = parseGraphDoc({
+  schemaVersion: SCHEMA_VERSION,
+  kind: "graph",
+  title: "알림 발송을 대기열로 옮기기",
+  summary: "발송 API가 게이트웨이를 직접 부르던 것을 대기열에 넣는 것으로 바꿉니다.",
+  lenses: ["architecture", "data-flow"],
+  provenance: {
+    repo: { owner: "coldteadotai", name: "pr-lens" },
+    base: { sha: "1111111" },
+    head: { sha: "2222222" },
+  },
+  lanes: [
+    { id: "app", label: "앱", subtitle: "アプリ", order: 0 },
+    { id: "workers", label: "워커", subtitle: "workers", order: 1 },
+  ],
+  nodes: [
+    {
+      id: "route",
+      label: "알림 발송 API",
+      kind: "route",
+      delta: "modified",
+      lane: "app",
+      subtitle: "createNotification",
+      files: [{ path: "src/routes/notify.ts" }],
+    },
+    {
+      id: "queue",
+      label: "通知キュー",
+      kind: "queue",
+      delta: "added",
+      lane: "workers",
+      subtitle: "notification-jobs",
+    },
+    {
+      id: "store",
+      label: "发送记录",
+      kind: "datastore",
+      delta: "added",
+      lane: "workers",
+      subtitle: "delivery_log",
+    },
+    {
+      id: "gateway",
+      label: "delivery gateway",
+      kind: "external",
+      delta: "unchanged",
+      lane: "workers",
+    },
+  ],
+  edges: [
+    {
+      id: "route-queue",
+      from: "route",
+      to: "queue",
+      kind: "queue",
+      delta: "added",
+      label: "발송 작업 하나를 대기열에 넣습니다",
+      emphasis: "hero",
+      animated: true,
+    },
+    {
+      id: "queue-store",
+      from: "queue",
+      to: "store",
+      kind: "data",
+      delta: "added",
+      label: "送信記録を一件書き込みます",
+    },
+    {
+      id: "store-gateway",
+      from: "store",
+      to: "gateway",
+      kind: "http",
+      delta: "unchanged",
+      label: "hands the record to the gateway",
+    },
+  ],
+  flows: [
+    {
+      id: "notify",
+      title: "발송 순서",
+      delta: "modified",
+      participants: [
+        { node: "route" },
+        { node: "queue" },
+        { node: "store" },
+        { node: "gateway" },
+      ],
+      messages: [
+        {
+          id: "enqueue",
+          from: "route",
+          to: "queue",
+          label: "발송 작업 하나를 대기열에 넣습니다",
+          kind: "async",
+          delta: "added",
+        },
+        {
+          id: "record",
+          from: "queue",
+          to: "store",
+          label: "送信記録を一件書き込みます",
+          kind: "sync",
+          delta: "added",
+        },
+        {
+          id: "handoff",
+          from: "store",
+          to: "gateway",
+          label: "把这条记录发送给网关",
+          kind: "sync",
+          delta: "unchanged",
+        },
+        {
+          id: "result",
+          from: "gateway",
+          to: "store",
+          label: "delivery result comes back",
+          kind: "return",
+          delta: "unchanged",
+        },
+      ],
+    },
+  ],
+});

--- a/packages/renderer/test/render.test.ts
+++ b/packages/renderer/test/render.test.ts
@@ -6,6 +6,7 @@ import {
 import { parseRenderManifest } from "@coldtea/pr-lens-schema";
 import { describe, expect, it } from "vitest";
 import { PrLensRenderError, render, renderAll, THEMES } from "../src/index.js";
+import { cjkGraph } from "./cjk.js";
 import { expectGolden } from "./goldens.js";
 
 describe("golden renders", () => {
@@ -42,6 +43,16 @@ describe("golden renders", () => {
   it("draws a single node", () => {
     const { svg } = render(minimalGraph, { lens: "architecture", theme: "light" });
     expectGolden("minimal.architecture.light.svg", svg);
+  });
+
+  it("draws full-width scripts at the width they take", () => {
+    const { svg } = render(cjkGraph, { lens: "architecture", theme: "dark" });
+    expectGolden("cjk.architecture.dark.svg", svg);
+  });
+
+  it("fits a plate to a full-width label", () => {
+    const { svg } = render(cjkGraph, { lens: "data-flow", theme: "dark" });
+    expectGolden("cjk.data-flow.dark.svg", svg);
   });
 });
 

--- a/packages/renderer/test/units.test.ts
+++ b/packages/renderer/test/units.test.ts
@@ -42,6 +42,17 @@ describe("text measurement", () => {
   it("charges every monospace character the same", () => {
     expect(measure("iiii", "mono", 10)).toBe(measure("mmmm", "mono", 10));
   });
+
+  it("charges a full-width character a whole em", () => {
+    expect(measure("한", "sans", 10)).toBe(10);
+    expect(measure("字", "sans", 10)).toBe(10);
+  });
+
+  it("makes a CJK label wider than as many of the widest Latin letter", () => {
+    expect(measure("가나다라", "sans", 13)).toBeGreaterThan(
+      measure("mmmm", "sans", 13),
+    );
+  });
 });
 
 describe("truncation", () => {


### PR DESCRIPTION
Closes #20.

`measure` charged every character outside the ASCII advance table the narrow
fallback of 600 per 1000 em. East Asian Wide and Fullwidth glyphs take a full
em, so a CJK label measured at 60% of the width it draws and its plate stopped
covering it.

`advanceFor` now routes an unlisted character through a range check that
answers 1000 for the wide blocks and 600 for everything else. No font engine,
so the renderer stays deterministic.

## Tests

Two in `units.test.ts` on `measure` itself.

Two goldens over a new fixture, `test/cjk.ts`, carrying Hangul, kana and Han:
`cjk.architecture.dark.svg` covers node titles, lane headers and card
subtitles, and `cjk.data-flow.dark.svg` covers message labels, which is where
the plate is most visible. Latin labels sit in both, so a golden that moved
because the layout shifted reads differently from one where the wide
measurements changed.

Reverting `text.ts` fails exactly those four and nothing else.

## Verification

`pnpm verify` is green at 492 tests. The 13 existing goldens are byte-identical,
since the only characters outside the table they use are the em dash, the middle
dot and the florin sign, all outside the wide ranges. I read both new goldens in
Chrome before recording them.
