### PR TITLE
Privacy and security docs for canvases

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,10 @@
+# Privacy
+
+The packages in this repository run on your machine or in your CI and report nothing to us. `analyze` sends the diff to the model provider you named, with your own key, and that request goes to the provider directly.
+
+The hosted parts of PR Lens, the GitHub App, prlens.dev and the canvases `pr-lens canvas push` publishes there, are covered by the privacy policy and terms on the site:
+
+- [Privacy policy](https://prlens.dev/privacy): what is received, where it is kept, who can read it, how to have it deleted, and the sub-processors with their regions.
+- [Terms of service](https://prlens.dev/terms)
+
+Questions, deletion requests and data processing agreements go to hello@coldtea.ai.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security
+
+If you find a vulnerability in PR Lens, in the packages here, in the GitHub App, or in prlens.dev, email hello@coldtea.ai and put "PR Lens security" in the subject line. Please do not open a public issue for it: an issue is read by everyone before it is read by us.
+
+Tell us what you found, how to reproduce it, and what it lets an attacker do. We answer every report, and we will tell you when it is fixed.
+
+The [privacy policy](https://prlens.dev/privacy) says what the hosted parts store and where, which is usually the first thing a reviewer wants to know.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -110,14 +110,15 @@ The map is a snapshot, not a source of truth. Nothing reads it back into the pip
 pr-lens canvas push
 ```
 
-Puts the document on prlens.dev as a canvas: a page anyone with the link can read, and an SVG a README can embed.
+Puts the document on prlens.dev as a canvas: a page anyone you share it with can read, and an SVG a README can embed.
 
-`push` sends the JSON document, never an SVG; the app draws it. The default is `.pr-lens/drawn.graph.json`, the document `render` drew, so what the page shows is what the diagrams show. The first push of a file mints a canvas and every push after that updates the same one, matched by the path it came from. `--canvas <id|name>` picks a different one and `--name` says what to call a new one; the document's title is the default. It prints three links:
+`push` sends the JSON document, never an SVG; the app draws it. The default is `.pr-lens/drawn.graph.json`, the document `render` drew, so what the page shows is what the diagrams show. The first push of a file mints a canvas and every push after that updates the same one, matched by the path it came from. `--canvas <id|name>` picks a different one and `--name` says what to call a new one; the document's title is the default. It prints the view link, the embed, and the way to take it down again:
 
 ```
 ✓ https://prlens.dev/c/{id} — rev 1 · 4 diagrams
-  edit link, keep it to yourself: https://prlens.dev/c/{id}#w=…
+  unlisted: anyone you share it with can open it, no sign-in needed
   README embed: https://prlens.dev/c/{id}.svg
+  remove: pr-lens canvas delete
 ```
 
 The view link is the one to share. The edit link is the same page with the write token in the fragment, and anyone holding it can push over your canvas, so it stays with you. The embed is the hero diagram as an SVG, for a README or a wiki.
@@ -127,6 +128,10 @@ A canvas plays the document's walkthrough when it carries one. The app checks th
 `pull` fetches the document back, by the view link or the bare id, into `.pr-lens/graph.json` unless `-o` says otherwise, and records the revision. Pull the edit link, the one ending in `#w=…`, and its token is recorded too: that is how a fresh checkout, or one that lost `.pr-lens/canvas.json`, gets the canvas back. A push carries the revision it last saw, and one that has been overtaken is refused rather than applied: pull, then push again.
 
 `rotate` mints a new write token and retires the old one. Use it when an edit link has leaked. The CLI saves the new token before it sends the request, so if the connection drops, the next command finishes the rotation instead of losing the token. The token lives in `.pr-lens/canvas.json`, keyed by canvas id, and git ignores it. Lose that file and the canvas is still readable by everyone; pushing to it again needs the token, which the edit link still carries.
+
+`delete` removes the hosted canvas: the document, every revision of it, and the images drawn from it, at once and for good. It needs the write token, like `push`. The local graph and SVG files stay where they are.
+
+A canvas is a labelled map of a system, so before pushing one it is fair to ask where it goes. The short answer: it can be opened by anyone you share it with and nobody else, it is never listed or indexed, it is kept in the EU until you delete it, and nothing is done with it beyond drawing the page. The long answer, with every company that touches it and the region each runs in, is the [privacy policy](https://prlens.dev/privacy).
 
 Registry writes take a lock at `.pr-lens/canvas.json.lock`. The CLI never removes another command's lock. If a command dies and leaves one behind, the error names its process id and you remove the file yourself.
 

--- a/packages/cli/src/commands/canvas.ts
+++ b/packages/cli/src/commands/canvas.ts
@@ -44,8 +44,8 @@ const isSubcommand = (value: string): value is Subcommand =>
 
 export const USAGE = `pr-lens canvas <push | pull | rotate | delete> [options]
 
-Keeps a graph document on the PR Lens app as a canvas: a page anyone with the
-link can read, and an SVG a README can embed. The write token lands in
+Keeps a graph document on the PR Lens app as a canvas: a page anyone you share
+it with can read, and an SVG a README can embed. The write token lands in
 ${REGISTRY_PATH}, which git ignores; the edit link carries the same token
 in its fragment, so share the view link and keep the edit link to yourself.
 
@@ -275,7 +275,7 @@ const push = async (
   terminal.out(
     `✓ ${pushed.viewUrl} — rev ${pushed.rev} · ${countDiagrams(pushed.tiles.length)}`,
   );
-  terminal.out("  unlisted: anyone you give the link can open it, no sign-in needed");
+  terminal.out("  unlisted: anyone you share it with can open it, no sign-in needed");
   terminal.out(`  README embed: ${pushed.embedUrl}`);
   terminal.out("  remove: pr-lens canvas delete");
 };

--- a/packages/cli/test/canvas-push.test.ts
+++ b/packages/cli/test/canvas-push.test.ts
@@ -18,7 +18,7 @@ test("the first push records a canvas and prints its links, access warning, and 
 
   expect(output.out).toEqual([
     `✓ ${API}/c/${FIRST} — rev 1 · 2 diagrams`,
-    "  unlisted: anyone you give the link can open it, no sign-in needed",
+    "  unlisted: anyone you share it with can open it, no sign-in needed",
     `  README embed: ${API}/c/${FIRST}.svg`,
     "  remove: pr-lens canvas delete",
   ]);


### PR DESCRIPTION
Closes #14.

The policy itself lives on the site (prlens.dev)

- `PRIVACY.md`: the packages report nothing; the hosted parts are covered by [prlens.dev/privacy](https://prlens.dev/privacy) and [prlens.dev/terms](https://prlens.dev/terms).
- `SECURITY.md`: where to report a vulnerability, and a request not to do it in a public issue.
- CLI README, `canvas` section: documents `delete`, shows the lines `push` prints today, and says in a paragraph who can read a canvas, how long it is kept, and where, with a link to the policy.

